### PR TITLE
Adds link to troubleshooting docs and removes healthcheck for UI. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Even if not you can try Hypertrace with sample application by running
 ```
 docker-compose -f docker-compose-zipkin-example.yml up
 ```
-Example app will be served at http://localhost:8081 . You can visit app to generate some sample requests!
+Example app will be served at http://localhost:8081 . You can visit URL and refresh it few times to generate some sample requests!
 
 ## Deploying with Kubernetes
 Please refer to [deployments](https://docs.hypertrace.org/deployments/) section in documentation which lists down steps for deploying Hypertrace on different Kubernetes flavors across different operating systems along with all major cloud providers. You can find the helm charts and installation script with more details [here](/kubernetes).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you want to see Hypertrace in action, you can quickly start Hypertrace via Do
 ```
 git clone https://github.com/hypertrace/hypertrace.git
 cd hypertrace/docker
+docker-compose pull
 docker-compose -f docker-compose.yml up
 ```
 This will start all services required for Hypertrace. Once you see the service `Hypertrace-UI` start, you can visit Hypertrace UI at http://localhost:2020 . 

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,6 +20,8 @@ This will start all services required for Hypertrace. Once you see the service h
 |:--:| 
 | *Hypertrace Dashboard* |
 
+If you are facing any issues with docker-compose setup, we have listed down common issues and resolutions [here](https://docs.hypertrace.org/troubleshooting/docker-compose/).
+
 ### Ports
 
 Here are the default Hypertrace ports:
@@ -36,4 +38,4 @@ Here are the default Hypertrace ports:
 - The example app has two services: frontend and backend. They both report trace data to Hypertrace. To setup the demo, you need to start Frontend, Backend and Hypertrace. 
 - You can start sample by running `docker-compose -f docker-compose-zipkin-example.yml up` if you have hypertrace running already. 
 - You can start sample app with Hypertrace using `docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up`.
-- Example app will be served at http://localhost:8081 . You can visit app to generate some sample requests!
+- Example app will be served at http://localhost:8081 . You can visit app and refresh it few times to generate some sample requests!

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,6 +11,7 @@ If you want to see Hypertrace in action, you can quickly start Hypertrace via Do
 ```
 git clone https://github.com/hypertrace/hypertrace.git
 cd hypertrace/docker
+docker-compose pull
 docker-compose -f docker-compose.yml up
 ```
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,12 +12,6 @@ services:
   hypertrace-ui:
     image: hypertrace/hypertrace-ui
     container_name: hypertrace-ui
-    # todo: move health check to dockerfile
-    healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "2020"]
-      interval: 2s
-      timeout: 1s
-      retries: 8
     ports:
       - 2020:2020
     depends_on:


### PR DESCRIPTION
- healthcheck for UI is moved to image so removed that from docker-compose. (https://github.com/hypertrace/hypertrace-ui/pull/110)
- Added link to troubleshooting doc. 
- Added `docker-compose pull` as explicit step as per the discussion. 