### PR TITLE
Updates to new kafka-zookeeper image inlining healthcheck

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 ## This does everything you need to get a hypertracing system started.
 ## You can connect to the UI at port 2020 and send data to it on any supported tracing solution.
-## Note: Our stack is dependent on pinot and it is a cpu heavy during startup. 
-## The depends_on has a max wait time of 1 min, so if you don't have enough resources, you may have to re-run the same command. 
+## Note: Our stack is dependent on pinot and it is a cpu heavy during startup.
+## The depends_on has a max wait time of 1 min, so if you don't have enough resources, you may have to re-run the same command.
 ## we are looking at improving this.
 version: '2.4'
 services:
@@ -176,13 +176,8 @@ services:
   # Kafka is used for streaming functionality.
   # ZooKeeper is required by Kafka and Pinot
   kafka-zookeeper:
-    image: hypertrace/kafka-zookeeper:0.1.4
+    image: hypertrace/kafka-zookeeper
     container_name: kafka-zookeeper
-    # todo : we will move this to docker image
-    healthcheck:
-      test: nc -z localhost 9092 && echo ruok | nc localhost 2181
-      interval: 2s
-      timeout: 1s
     networks:
       default:
         # prevents apps from having to use the hostname kafka-zookeeper


### PR DESCRIPTION
note the succinct command for kafka-zookeeper

```bash
$ docker-compose ps
            Name                          Command                  State                                               Ports                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
all-views-creator              wait-for-it.sh -h pinot -p ...   Exit 0                                                                                              
all-views-generator            java -cp /app/resources:/a ...   Up (healthy)   8099/tcp                                                                             
attributes-bootstrapper        wait-for-it.sh -h hypertra ...   Exit 0                                                                                              
hypertrace-collector           /occollector_linux --confi ...   Up             0.0.0.0:14267->14267/tcp, 0.0.0.0:14268->14268/tcp, 55678/tcp, 0.0.0.0:9411->9411/tcp
hypertrace-federated-service   wait-for-it.sh -h pinot -p ...   Up (healthy)   0.0.0.0:2020->2020/tcp, 9001/tcp, 9002/tcp                                           
hypertrace-trace-enricher      java -cp /app/resources:/a ...   Up (healthy)   8099/tcp                                                                             
kafka-zookeeper                start-kafka-zookeeper            Up (healthy)   19092/tcp, 2181/tcp, 9092/tcp                                                        
mongo                          /root/run.sh mongod --bind ...   Up (healthy)   27017/tcp, 28017/tcp                                                                 
pinot                          ./bin/pinot-admin.sh Start ...   Up (healthy)   8096/tcp, 8097/tcp, 8098/tcp, 8099/tcp, 9000/tcp, 9514/tcp                           
raw-spans-grouper              java -cp /app/resources:/a ...   Up (healthy)   8099/tcp                                                                             
schema-registry                /usr/bin/docker-start.sh         Up (healthy)   8081/tcp                                                                             
span-normalizer                java -cp /app/resources:/a ...   Up (healthy)   8099/tcp                     
```