### PR TITLE
Removes deps from pinot for federated service 

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,27 +12,13 @@ services:
   hypertrace-federated-service:
     image: hypertrace/hypertrace-federated-service
     container_name: hypertrace-federated-service
-    volumes: &default-scripts
-      # These scripts are temporary, allowing a temporary override the ENTRYPOINT with a blocking barrier.
-      # Unlike service_started condition, these barriers can be longer than a minute. These are temporary
-      # because they shadow the ENTRYPOINT, duplicate and ignore the more robust HEALTHCHECK
-      # feature available in commands like docker ps.
-      #
-      # TODO: Remove this after startup improvement fixes
-      - ./scripts/wait-for-it.sh:/usr/local/bin/wait-for-it.sh:ro
-      - ./scripts/start-platform.sh:/usr/local/bin/start-platform.sh:ro
-      - ./scripts/start-bootstrapper.sh:/usr/local/bin/start-bootstrapper.sh:ro
     environment:
       - MONGO_HOST=mongo
       - ZK_CONNECT_STR=zookeeper:2181/hypertrace-views
-    # TODO: Remove this after startup improvement fixes
-    entrypoint: ["wait-for-it.sh", "-h", "pinot", "-p", "8097", "--timeout=120",
-                 "--" ,
-                 "start-platform.sh"]
     ports:
       - 2020:2020
     healthcheck:
-      start_period: 120s
+      start_period: 20s
     depends_on:
       mongo:
         condition: service_healthy
@@ -136,9 +122,18 @@ services:
       # todo : we are in process of making them as part of default.
       - PINOT_BROKER_TAG=DefaultTenant
       - PINOT_SERVER_TAG=DefaultTenant
-    volumes: *default-scripts
+    volumes: &default-scripts
+      # These scripts are temporary, allowing a temporary override the ENTRYPOINT with a blocking barrier.
+      # Unlike service_started condition, these barriers can be longer than a minute. These are temporary
+      # because they shadow the ENTRYPOINT, duplicate and ignore the more robust HEALTHCHECK
+      # feature available in commands like docker ps.
+      #
+      # TODO: Remove this after startup improvement fixes
+      - ./scripts/wait-for-it.sh:/usr/local/bin/wait-for-it.sh:ro
+      - ./scripts/start-platform.sh:/usr/local/bin/start-platform.sh:ro
+      - ./scripts/start-bootstrapper.sh:/usr/local/bin/start-bootstrapper.sh:ro
     # TODO: Remove this after startup improvement fixes
-    entrypoint: ["wait-for-it.sh", "-h", "pinot", "-p", "8097", "--timeout=120",
+    entrypoint: ["wait-for-it.sh", "-h", "pinot", "-p", "8097", "--timeout=180",
                  "--" ,
                  "start-platform.sh"]
     depends_on:


### PR DESCRIPTION
QueryService is part of federated services that fetches data from pinot. QueryServices fetches brokers lists for pinot via zookeeper with data changed watcher. So, this will help us to start federated service parallel to pinot, but it will able to server traffic correctly when pinot will be healthy. But, to improve startup time, removing deps from pinot for federated service.