### PR TITLE
Finishes all 3rd party images, notably Pinot

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -171,7 +171,7 @@ services:
   # Kafka is used for streaming functionality.
   # ZooKeeper is required by Kafka and Pinot
   kafka-zookeeper:
-    image: hypertrace/kafka-zookeeper
+    image: hypertrace/kafka-zookeeper:main
     container_name: kafka-zookeeper
     networks:
       default:
@@ -193,30 +193,20 @@ services:
     command: ["mongod", "--quiet", "--bind_ip", "0.0.0.0"]
   # Stores spans and traces and provides aggregation functions
   pinot:
-    image: hypertrace/pinot-servicemanager:0.1.3
+    image: hypertrace/pinot-servicemanager:main
     container_name: pinot
-    environment:
-      - JAVA_OPTS=-Xms256M -Xmx512M -XX:MaxDirectMemorySize=96M -XX:+ExitOnOutOfMemoryError
     networks:
       default:
         # Usually, Pinot is distributed, and clients connect to the controller
         aliases:
           - pinot-controller
     cpu_shares: 2048
-    # TODO: move health check to dockerfile
-    healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "8097"]
-      interval: 1s
-      timeout: 1s
-      retries: 15
-      start_period: 45s
-    command: StartServiceManager -clusterName hypertrace-views  -zkAddress zookeeper:2181 -port 7098 -bootstrapConfigPaths /opt/pinot/etc/pinot-controller.conf /opt/pinot/etc/pinot-broker.conf /opt/pinot/etc/pinot-server.conf
     depends_on:
       kafka-zookeeper:
         condition: service_healthy
   # Hypertrace formats are defined in Avro. This helps maintain version compatibility.
   schema-registry:
-    image: hypertrace/schema-registry
+    image: hypertrace/schema-registry:main
     container_name: schema-registry
     depends_on:
       kafka-zookeeper:


### PR DESCRIPTION
When this change is merged, by default we use the :main tag for 3rd
party services (except mongo which lacks a HT image)

Most notably, this uses the much faster Pinot build which depending
on laptop starts in less than 30s even when thrashed by all the other
processes:

```bash
$ docker logs pinot 2>&1|grep 'since launch'
07:17:50,407 INFO  [main] command.StartServiceManagerCommand (StartServiceManagerCommand.java:285) - Starting a Pinot [SERVICE_MANAGER] at 0.027s since launch
07:17:57,815 INFO  [main] command.StartServiceManagerCommand (StartServiceManagerCommand.java:287) - Started Pinot [SERVICE_MANAGER] instance [ServiceManager_d428313909fb_7098] at 7.436s since launch
07:17:57,874 INFO  [main] command.StartServiceManagerCommand (StartServiceManagerCommand.java:285) - Starting a Pinot [CONTROLLER] at 7.495s since launch
07:18:10,649 INFO  [main] command.StartServiceManagerCommand (StartServiceManagerCommand.java:287) - Started Pinot [CONTROLLER] instance [Controller_d428313909fb_9000] at 20.27s since launch
07:18:10,651 INFO  [Start a Pinot [BROKER]] command.StartServiceManagerCommand (StartServiceManagerCommand.java:285) - Starting a Pinot [BROKER] at 20.272s since launch
07:18:10,659 INFO  [Start a Pinot [SERVER]] command.StartServiceManagerCommand (StartServiceManagerCommand.java:285) - Starting a Pinot [SERVER] at 20.279s since launch
07:18:19,874 INFO  [Start a Pinot [SERVER]] command.StartServiceManagerCommand (StartServiceManagerCommand.java:287) - Started Pinot [SERVER] instance [Server_d428313909fb_8098] at 29.529s since launch
07:18:20,324 INFO  [Start a Pinot [BROKER]] command.StartServiceManagerCommand (StartServiceManagerCommand.java:287) - Started Pinot [BROKER] instance [Broker_d428313909fb_8099] at 29.979s since launch
```