### PR TITLE
chore(ci): enables basic CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,15 @@ jobs:
       - checkout
       - run: |
           cd ./docker
-          docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up -d || (docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml logs; exit 1)
+          docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up -d pinot || (docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml logs; exit 1)
+          sleep 60
       - run: |
           cd ./docker
-          sleep 30
+          docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml ps
+          docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up -d || (docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml logs; exit 1)
+      - run: |
+          sleep 10
+          cd ./docker
           docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml ps
           curl -I localhost:2020
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       image: ubuntu-1604:201903-01 # Note: There is an overhead for provisioning a machine executor as a result of spinning
       # up a private Docker server. Use of the machine key may require additional fees in a future pricing update.
       docker_layer_caching: true
-
+    resource_class: large
     working_directory: ~/hypertrace
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+
+jobs:
+  build:
+    # We use machine executor as docker executor won't allow mounting of folders.
+    machine:
+      image: ubuntu-1604:201903-01 # Note: There is an overhead for provisioning a machine executor as a result of spinning
+      # up a private Docker server. Use of the machine key may require additional fees in a future pricing update.
+      docker_layer_caching: true
+
+    working_directory: ~/hypertrace
+    steps:
+      - checkout
+      - run: |
+          cd ./docker
+          docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up -d || (docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml logs; exit 1)
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,13 @@ jobs:
       - run: |
           cd ./docker
           docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up -d pinot || (docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml logs; exit 1)
-          sleep 60
+          sleep 80
       - run: |
           cd ./docker
           docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml ps
           docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up -d || (docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml logs; exit 1)
       - run: |
-          sleep 10
+          sleep 20
           cd ./docker
           docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml ps
           curl -I localhost:2020

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,11 @@ jobs:
       - run: |
           cd ./docker
           docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up -d || (docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml logs; exit 1)
+      - run: |
+          cd ./docker
+          sleep 30
+          docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml ps
+          curl -I localhost:2020
 
 workflows:
   version: 2


### PR DESCRIPTION
This PR enables a basic CI for the repository, launching containers from docker-compose and calling the API.

If this becomes green I'd suggest we only allow merges when this is green. Making sure this is the source of truth.

Ping @adriancole @kotharironak @JBAhire 