### PR TITLE
Removes the all-views-creator as startup jobs

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -113,40 +113,6 @@ services:
       schema-registry:
         condition: service_started
 
-# One time startup jobs:
-
-  # Creates require views in pinot like spanEventView, backendEntityView, etc
-  all-views-creator:
-    image: hypertrace/hypertrace-view-creator
-    container_name: all-views-creator
-    environment:
-      - SERVICE_NAME=all-views
-      - SCHEMA_REGISTRY_URL=http://schema-registry:8081
-      - ZK_CONNECT_STR=zookeeper:2181
-      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
-      # todo : we are in process of making them as part of default.
-      - PINOT_BROKER_TAG=DefaultTenant
-      - PINOT_SERVER_TAG=DefaultTenant
-    volumes: &default-scripts
-      # These scripts are temporary, allowing a temporary override the ENTRYPOINT with a blocking barrier.
-      # Unlike service_started condition, these barriers can be longer than a minute. These are temporary
-      # because they shadow the ENTRYPOINT, duplicate and ignore the more robust HEALTHCHECK
-      # feature available in commands like docker ps.
-      #
-      # TODO: Remove this after startup improvement fixes
-      - ./scripts/wait-for-it.sh:/usr/local/bin/wait-for-it.sh:ro
-      - ./scripts/start-platform.sh:/usr/local/bin/start-platform.sh:ro
-      - ./scripts/start-bootstrapper.sh:/usr/local/bin/start-bootstrapper.sh:ro
-    # TODO: Remove this after startup improvement fixes
-    entrypoint: ["wait-for-it.sh", "-h", "pinot", "-p", "8097", "--timeout=180",
-                 "--" ,
-                 "start-platform.sh"]
-    depends_on:
-      pinot:
-        # note : To work successfully, it needs pinot to be healthy. This has started parallel for
-        # startup experience.
-        condition: service_started
-
 # Third-party data services:
 
   # Kafka is used for streaming functionality.
@@ -174,7 +140,7 @@ services:
     command: ["mongod", "--quiet", "--bind_ip", "0.0.0.0"]
   # Stores spans and traces and provides aggregation functions
   pinot:
-    image: hypertrace/pinot-servicemanager:main
+    image: jbhire/pinot-servicemanager:test
     container_name: pinot
     networks:
       default:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -140,7 +140,7 @@ services:
     command: ["mongod", "--quiet", "--bind_ip", "0.0.0.0"]
   # Stores spans and traces and provides aggregation functions
   pinot:
-    image: jbhire/pinot-servicemanager:test
+    image: jbahire/pinot-servicemanager:test
     container_name: pinot
     networks:
       default:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -140,7 +140,7 @@ services:
     command: ["mongod", "--quiet", "--bind_ip", "0.0.0.0"]
   # Stores spans and traces and provides aggregation functions
   pinot:
-    image: jbahire/pinot-servicemanager:test
+    image: hypertrace/pinot-servicemanager:main
     container_name: pinot
     networks:
       default:

--- a/docker/misc/docker-compose-tools.yml
+++ b/docker/misc/docker-compose-tools.yml
@@ -2,14 +2,26 @@
 version: '2.4'
 services:
 
-# Handy tool for manually creating require attributes into mongo like entity type, its relationship, etc
-config-bootstrapper:
-  image: hypertrace/config-bootstrapper
-  container_name: attributes-bootstrapper
-  environment:
-    - SERVICE_NAME=config-bootstrapper
-    - ATTRIBUTE_SERVICE_HOST_CONFIG=hypertrace-federated-service
-    - ATTRIBUTE_SERVICE_PORT_CONFIG=9001
-    - ENTITY_SERVICE_HOST_CONFIG=hypertrace-federated-service
-    - ENTITY_SERVICE_PORT_CONFIG=9001
-    - MONGO_HOST=mongo
+  # Handy tool for manually creating require attributes into mongo like entity type, its relationship, etc
+  config-bootstrapper:
+    image: hypertrace/config-bootstrapper
+    container_name: attributes-bootstrapper
+    environment:
+      - SERVICE_NAME=config-bootstrapper
+      - ATTRIBUTE_SERVICE_HOST_CONFIG=hypertrace-federated-service
+      - ATTRIBUTE_SERVICE_PORT_CONFIG=9001
+      - ENTITY_SERVICE_HOST_CONFIG=hypertrace-federated-service
+      - ENTITY_SERVICE_PORT_CONFIG=9001
+      - MONGO_HOST=mongo
+  # Creates require views in pinot like spanEventView, backendEntityView, etc
+  all-views-creator:
+    image: hypertrace/hypertrace-view-creator
+    container_name: all-views-creator
+    environment:
+      - SERVICE_NAME=all-views
+      - SCHEMA_REGISTRY_URL=http://schema-registry:8081
+      - ZK_CONNECT_STR=zookeeper:2181
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      # todo : we are in process of making them as part of default.
+      - PINOT_BROKER_TAG=DefaultTenant
+      - PINOT_SERVER_TAG=DefaultTenant


### PR DESCRIPTION
we have moved all-views-creator which install schema as part of bootstrapping as pinot image itself. Ref PR - https://github.com/hypertrace/pinot/pull/28

So, this PR removes it and moves to misc for one-time use if needed.