### PR TITLE
renames hypertrace-federated-service to hypertrace

### DIFF
--- a/.circleci/tests.sh
+++ b/.circleci/tests.sh
@@ -15,7 +15,7 @@ echo ""
 echo "Making sure the traces service is up..."
 
 # curl --retry-connrefused is only available since 7.52.0.
-NUMBER_OF_RETRIES=50
+NUMBER_OF_RETRIES=30
 RETRY_COUNT=0
 while : ; do
   if [[ "$RETRY_COUNT" == "$NUMBER_OF_RETRIES" ]]; then

--- a/.circleci/tests.sh
+++ b/.circleci/tests.sh
@@ -15,7 +15,7 @@ echo ""
 echo "Making sure the traces service is up..."
 
 # curl --retry-connrefused is only available since 7.52.0.
-NUMBER_OF_RETRIES=20
+NUMBER_OF_RETRIES=50
 RETRY_COUNT=0
 while : ; do
   if [[ "$RETRY_COUNT" == "$NUMBER_OF_RETRIES" ]]; then

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,12 +6,10 @@
 version: '2.4'
 services:
 
-# Frontend Services
-
-  # Serves GraphQL and gRPC requests that cross different backends like Pinot and Mongo
-  hypertrace-federated-service:
-    image: hypertrace/hypertrace-federated-service
-    container_name: hypertrace-federated-service
+# This container includes the UI and APIs it needs for storage queries.
+  hypertrace:
+    image: hypertrace/hypertrace:test
+    container_name: hypertrace
     environment:
       - MONGO_HOST=mongo
       - ZK_CONNECT_STR=zookeeper:2181/hypertrace-views
@@ -86,7 +84,7 @@ services:
     environment:
       - SCHEMA_REGISTRY_URL=http://schema-registry:8081
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
-      - ENTITY_SERVICE_HOST_CONFIG=hypertrace-federated-service
+      - ENTITY_SERVICE_HOST_CONFIG=hypertrace
       - ENTITY_SERVICE_PORT_CONFIG=9001
       - KAFKA_SINK_TOPIC=enriched-structured-traces
     volumes: *default-log-config
@@ -95,7 +93,7 @@ services:
         condition: service_started
       schema-registry:
         condition: service_started
-      hypertrace-federated-service:
+      hypertrace:
         condition: service_started
   # materialize enriched traces into pinot views
   all-views-generator:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
 # This container includes the UI and APIs it needs for storage queries.
   hypertrace:
-    image: hypertrace/hypertrace:test
+    image: hypertrace/hypertrace:main
     container_name: hypertrace
     environment:
       - MONGO_HOST=mongo

--- a/docker/misc/docker-compose-tools.yml
+++ b/docker/misc/docker-compose-tools.yml
@@ -8,9 +8,9 @@ services:
     container_name: attributes-bootstrapper
     environment:
       - SERVICE_NAME=config-bootstrapper
-      - ATTRIBUTE_SERVICE_HOST_CONFIG=hypertrace-federated-service
+      - ATTRIBUTE_SERVICE_HOST_CONFIG=hypertrace-service
       - ATTRIBUTE_SERVICE_PORT_CONFIG=9001
-      - ENTITY_SERVICE_HOST_CONFIG=hypertrace-federated-service
+      - ENTITY_SERVICE_HOST_CONFIG=hypertrace-service
       - ENTITY_SERVICE_PORT_CONFIG=9001
       - MONGO_HOST=mongo
   # Creates require views in pinot like spanEventView, backendEntityView, etc


### PR DESCRIPTION
This simplifies the terminology we use by getting rid of the term "federated". It also makes image discovery easier by calling the top level docker image "hypertrace"

This is WIP as it requires a publish to fix the helm side accordingly

depends on https://github.com/hypertrace/hypertrace-service/pull/25
see https://github.com/hypertrace/hypertrace-service/issues/18