### PR TITLE
chore(ci): disable docker_layer_caching to pull latest version always

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01 # Note: There is an overhead for provisioning a machine executor as a result of spinning
       # up a private Docker server. Use of the machine key may require additional fees in a future pricing update.
-      docker_layer_caching: true
+      docker_layer_caching: false
     resource_class: large
 
     working_directory: ~/hypertrace

--- a/.circleci/tests.sh
+++ b/.circleci/tests.sh
@@ -39,7 +39,7 @@ curl -o /dev/null -s http://${FRONTEND_SERVICE_HOST}:8081  || { echo "Host $FRON
 echo "Retrieving the list of traces."
 echo ""
 
-NUMBER_OF_RETRIES=20
+NUMBER_OF_RETRIES=30
 RETRY_COUNT=0
 TRACES=""
 while : ; do

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - ../docker/configs/log4j2.properties:/app/resources/log4j2.properties:ro
     depends_on:
       schema-registry:
-        condition: service_healthy
+        condition: service_started
       kafka-zookeeper:
         condition: service_healthy
   # Groups raw spans into traces based on a time interval


### PR DESCRIPTION
Since we don't have releases but use `main` all the time, it is good we avoid cache layers to make sure we always use last versions.

Ping @JBAhire @kotharironak 