### PR TITLE
updates span-normalizer with additional conditions and pre-create topics

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,13 +57,14 @@ services:
       - SCHEMA_REGISTRY_URL=http://schema-registry:8081
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - DEFAULT_TENANT_ID=__default
+      - PRE_CREATE_TOPICS=true
     volumes: &default-log-config
       - ../docker/configs/log4j2.properties:/app/resources/log4j2.properties:ro
     depends_on:
       schema-registry:
-        condition: service_started
+        condition: service_healthy
       kafka-zookeeper:
-        condition: service_started
+        condition: service_healthy
   # Groups raw spans into traces based on a time interval
   raw-spans-grouper:
     image: hypertrace/raw-spans-grouper


### PR DESCRIPTION
As we have moved to use KafkaStream, latest span-normalizer images need pre-creation on topics.
- refere issue https://github.com/hypertrace/kafka-streams-framework/issues/5
So, we now need service_healthy deps on span-normalizer. Updating that as part of this PR.