### PR TITLE
chore(ci): uses docker pull instead of disabling the cache to reuse cached layers.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01 # Note: There is an overhead for provisioning a machine executor as a result of spinning
       # up a private Docker server. Use of the machine key may require additional fees in a future pricing update.
-      docker_layer_caching: false
+      docker_layer_caching: true
     resource_class: large
 
     working_directory: ~/hypertrace
@@ -14,6 +14,7 @@ jobs:
       - checkout
       - run: |
           cd ./docker
+          docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml pull
           docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up -d || (docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml logs; exit 1)
       - run: |
           sleep 60 # you can decrease it but never increase it


### PR DESCRIPTION
Follows from #58

Ping @adriancole 