### PR TITLE
chore(ci): removes DLC from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01 # Note: There is an overhead for provisioning a machine executor as a result of spinning
       # up a private Docker server. Use of the machine key may require additional fees in a future pricing update.
-      docker_layer_caching: true
     resource_class: large
 
     working_directory: ~/hypertrace


### PR DESCRIPTION
DLC is a paid feature that cost 200 credits/run and we are not yet getting a real improvement out of it, hence removing it.

Ping @aaron-steinfeld 