### PR TITLE
chore: adds issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@ Welcome to the Hypertrace repo!
 
 - Please be respectful and considerate of others when commenting on issues.
 - Please search for existing issues in order to make sure we don't have duplicate bugs/feature requests.
-- If you have a question please ask it on our Gitter chat https://join.slack.com/t/hypertrace/shared_invite/zt-hgjlblic-Tq2_N4sHJj4RMqx5nirS9w instead of creating an issue.
+- If you have a question please ask it on our Slack chat https://join.slack.com/t/hypertrace/shared_invite/zt-hgjlblic-Tq2_N4sHJj4RMqx5nirS9w instead of creating an issue.
 - Please provide as much information as possible so we all understand the issue.
 -->
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Welcome to the Hypertrace repo!
+
+- Please be respectful and considerate of others when commenting on issues.
+- Please search for existing issues in order to make sure we don't have duplicate bugs/feature requests.
+- If you have a question please ask it on our Gitter chat https://join.slack.com/t/hypertrace/shared_invite/zt-hgjlblic-Tq2_N4sHJj4RMqx5nirS9w instead of creating an issue.
+- Please provide as much information as possible so we all understand the issue.
+-->
+
+## Use Case
+*Please describe your use case here, what are you trying to achieve e.g. "I want to collect only error traces"*
+
+## Proposal
+*A proposal that from your POV would solve the problem or improve the existing situation e.g. "I want the hypertrace-collector to have a filter for error traces". If you don't have a proposed solution, that's fine too.*
+
+## Questions to address (if any)
+*Questions that should be answered during the discussion of this issue before jumping into code. Also beneficial to test asumptions e.g. "Confirm that you support custom builds for collector".*


### PR DESCRIPTION
This PR adds an issue template for opening an issue on this repo. Since we don't have that many issues yet I believe this template is good enough, once we get issues more varied and often we can jump into something more sophisticated like https://github.com/openzipkin/zipkin/issues/new/choose
