### PR TITLE
updates helm charts

### DIFF
--- a/kubernetes/data-services/Chart.yaml
+++ b/kubernetes/data-services/Chart.yaml
@@ -28,13 +28,13 @@ dependencies:
     version: 0.1.2
   - name: kafka
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.6
+    version: 0.1.7
   - name: schema-registry
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.5
   - name: pinot
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.9
+    version: 0.2.3
   - name: mongodb
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.0

--- a/kubernetes/platform-services/Chart.yaml
+++ b/kubernetes/platform-services/Chart.yaml
@@ -28,22 +28,22 @@ dependencies:
     version: 0.1.5
   - name: span-normalizer
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.17
+    version: 0.1.23
   - name: raw-spans-grouper
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.14
   - name: hypertrace-trace-enricher
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.17
+    version: 0.1.26
   - name: hypertrace-view-generator
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.15
+    version: 0.1.22
   - name: hypertrace-ui
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.33.1
+    version: 0.37.5
   - name: hypertrace-graphql-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.3.0
+    version: 0.3.1
   - name: attribute-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.3.2
@@ -52,10 +52,10 @@ dependencies:
     version: 0.1.24
   - name: query-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.15
+    version: 0.3.2
   - name: entity-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.19
+    version: 0.1.23
   - name: hypertrace-federated-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.13


### PR DESCRIPTION
This PR,
- updates helm charts for all the services (except `raw-spans-grouper` and `hypertrace-service` ) to latest. 