### PR TITLE
Moves to a smaller and more efficient zipkin example app

### DIFF
--- a/docker/docker-compose-zipkin-example.yml
+++ b/docker/docker-compose-zipkin-example.yml
@@ -3,10 +3,10 @@ services:
   # Generate traffic by hitting http://localhost:8081
   frontend:
     container_name: frontend
-    image: openzipkin/example-sleuth-webmvc
-    command: Frontend
+    image: openzipkin/example-brave:armeria
+    command: frontend
     environment: 
-        - SPRING_SLEUTH_SUPPORTS-JOIN=false
+        - ZIPKIN_SUPPORTS_JOIN=false
     ports:
       - 8081:8081
     depends_on:
@@ -14,7 +14,7 @@ services:
         condition: service_started
   backend:
     container_name: backend
-    image: openzipkin/example-sleuth-webmvc
-    command: Backend
+    image: openzipkin/example-brave:armeria
+    command: backend
     environment: 
-        - SPRING_SLEUTH_SUPPORTS-JOIN=false
+        - ZIPKIN_SUPPORTS_JOIN=false


### PR DESCRIPTION
The new sample app is much more efficient and also smaller.
This should help reduce overall bootstrap load when running examples.

Here's a comparison before after during http requests in a for loop. Unscientific on load, but memory is definitely less.

before

```
openzipkin/example-sleuth-webmvc     latest              4b4354aa7433        7 days ago          428MB

CONTAINER ID        NAME                   CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
e8d2d9b71ea1        hypertrace-ingester    29.63%              377.7MiB / 1.944GiB   18.97%              646kB / 640kB       195MB / 156kB       48
427672a37f5c        hypertrace             71.20%              188.8MiB / 1.944GiB   9.48%               716kB / 649kB       212MB / 86kB        157
e760dee50c95        pinot                  6.69%               370.4MiB / 1.944GiB   18.60%              3.53MB / 2.07MB     1.39GB / 8.19kB     181
6a3918d471d7        hypertrace-collector   1.92%               8.043MiB / 1.944GiB   0.40%               368kB / 96.2kB      94.4MB / 0B         13
617f12d3c726        frontend               50.29%              147.2MiB / 1.944GiB   7.39%               259kB / 517kB       189MB / 0B          40
7b64a881ff29        kafka-zookeeper        13.74%              170.9MiB / 1.944GiB   8.58%               2.72MB / 4.1MB      116MB / 3.31MB      112
3f998130b23b        mongo                  15.71%              13.14MiB / 1.944GiB   0.66%               433kB / 505kB       315MB / 2.26MB      34
810c0030d86b        backend                78.65%              164.6MiB / 1.944GiB   8.27%               138kB / 231kB       229MB / 0B          40

```

after
```
openzipkin/example-brave             armeria             595fb2a7e231        19 minutes ago      108MB

CONTAINER ID        NAME                   CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
694cfaaf249b        hypertrace-ingester    144.84%             325.5MiB / 1.944GiB   16.35%              314kB / 310kB       92.6MB / 127kB      43
ecc6936dc00b        hypertrace             2.94%               212.1MiB / 1.944GiB   10.65%              220kB / 170kB       60.4MB / 86kB       155
b6987e17c20c        pinot                  6.95%               496.8MiB / 1.944GiB   24.95%              3.19MB / 1.8MB      1.32GB / 8.19kB     178
0a45aac27766        hypertrace-collector   0.76%               8.844MiB / 1.944GiB   0.44%               41.6kB / 58.8kB     54.4MB / 0B         14
5a73e3c84197        frontend               1.45%               81.73MiB / 1.944GiB   4.10%               145kB / 157kB       49.3MB / 2.68MB     33
0fce45929a65        backend                4.34%               62.73MiB / 1.944GiB   3.15%               53.3kB / 63.3kB     46.6MB / 86kB       33
7cedaec17924        kafka-zookeeper        17.53%              268.5MiB / 1.944GiB   13.49%              2.22MB / 3.58MB     61.8MB / 3.18MB     111
268d7614f46d        mongo                  1.08%               8.398MiB / 1.944GiB   0.42%               108kB / 127kB       106MB / 1.34MB      32
```