### PR TITLE
updates helm charts

### DIFF
--- a/kubernetes/clusters/dev/values.yaml
+++ b/kubernetes/clusters/dev/values.yaml
@@ -278,7 +278,7 @@ hypertrace-view-generator:
             - retention.ms=10800000
 
 hypertrace-federated-service:
-  enabled: true
+  enabled: false
   javaOpts: "-Xms256M -Xmx256M -XX:MaxDirectMemorySize=64M -XX:+ExitOnOutOfMemoryError"
   resources:
     requests:
@@ -295,7 +295,7 @@ hypertrace-federated-service:
     periodSeconds: 5
 
 gateway-service:
-  replicaCount: 0
+  replicaCount: 1
   containerPortName: grpc-port
   serviceSelectorLabels:
     app: hypertrace-federated-service
@@ -317,7 +317,7 @@ gateway-service:
         }
 
 entity-service:
-  replicaCount: 0
+  replicaCount: 1
   serviceSelectorLabels:
     app: hypertrace-federated-service
   config-bootstrapper:
@@ -331,7 +331,7 @@ entity-service:
         memory: "256Mi"
 
 attribute-service:
-  replicaCount: 0
+  replicaCount: 1
   serviceSelectorLabels:
     app: hypertrace-federated-service
   config-bootstrapper:
@@ -345,12 +345,12 @@ attribute-service:
         memory: "256Mi"
 
 query-service:
-  replicaCount: 0
+  replicaCount: 1
   serviceSelectorLabels:
     app: hypertrace-federated-service
 
 hypertrace-graphql-service:
-  replicaCount: 0
+  replicaCount: 1
   serviceSelectorLabels:
     app: hypertrace-federated-service
   configMap:

--- a/kubernetes/clusters/dev/values.yaml
+++ b/kubernetes/clusters/dev/values.yaml
@@ -188,6 +188,10 @@ raw-spans-grouper:
     initialDelaySeconds: 10
     periodSeconds: 5
   rawSpansGrouperConfig:
+    kafka:
+      streams:
+        config:
+          replicationFactor: 1
     span:
       groupby:
         internal: 10

--- a/kubernetes/clusters/dev/values.yaml
+++ b/kubernetes/clusters/dev/values.yaml
@@ -23,7 +23,7 @@ zookeeper:
     failureThreshold: 8
 
 kafka:
-  replicaCount: 3
+  replicaCount: 1
   javaOpts: "-Xms128M -Xmx384M -XX:MaxDirectMemorySize=64M -XX:+ExitOnOutOfMemoryError"
   resources:
     requests:

--- a/kubernetes/clusters/dev/values.yaml
+++ b/kubernetes/clusters/dev/values.yaml
@@ -23,7 +23,7 @@ zookeeper:
     failureThreshold: 8
 
 kafka:
-  replicaCount: 1
+  replicaCount: 3
   javaOpts: "-Xms128M -Xmx384M -XX:MaxDirectMemorySize=64M -XX:+ExitOnOutOfMemoryError"
   resources:
     requests:
@@ -128,9 +128,6 @@ pinot:
       timeoutSeconds: 1
       failureThreshold: 8
 
-  servicemanager:
-    enabled: false
-
 mongodb:
   replicaSet:
     enabled: false
@@ -175,6 +172,7 @@ span-normalizer:
     enabled: false
 
 raw-spans-grouper:
+  replicaCount: 1
   javaOpts: "-Xms128M -Xmx128M -XX:MaxDirectMemorySize=96M -XX:+ExitOnOutOfMemoryError"
   resources:
     requests:
@@ -277,49 +275,12 @@ hypertrace-view-generator:
             - retention.bytes=1073741824
             - retention.ms=10800000
 
-hypertrace-federated-service:
-  enabled: false
-  javaOpts: "-Xms256M -Xmx256M -XX:MaxDirectMemorySize=64M -XX:+ExitOnOutOfMemoryError"
-  resources:
-    requests:
-      cpu: "0.5"
-      memory: "384Mi"
-    limits:
-      cpu: "0.75"
-      memory: "384Mi"
-  livenessProbe:
-    initialDelaySeconds: 10
-    periodSeconds: 5
-  readinessProbe:
-    initialDelaySeconds: 10
-    periodSeconds: 5
-
 gateway-service:
   replicaCount: 1
   containerPortName: grpc-port
-  serviceSelectorLabels:
-    app: hypertrace-federated-service
-  configMap:
-    name: gateway-service-config
-    data:
-      application.conf: |-
-        entity.service.config = {
-          host = localhost
-          port = 9001
-        }
-        query.service.config = {
-          host = localhost
-          port = 9001
-        }
-        attributes.service.config = {
-          host = localhost
-          port = 9001
-        }
 
 entity-service:
   replicaCount: 1
-  serviceSelectorLabels:
-    app: hypertrace-federated-service
   config-bootstrapper:
     javaOpts: "-Xms128M -Xmx128M"
     resources:
@@ -332,8 +293,6 @@ entity-service:
 
 attribute-service:
   replicaCount: 1
-  serviceSelectorLabels:
-    app: hypertrace-federated-service
   config-bootstrapper:
     javaOpts: "-Xms128M -Xmx128M"
     resources:
@@ -346,26 +305,9 @@ attribute-service:
 
 query-service:
   replicaCount: 1
-  serviceSelectorLabels:
-    app: hypertrace-federated-service
 
 hypertrace-graphql-service:
   replicaCount: 1
-  serviceSelectorLabels:
-    app: hypertrace-federated-service
-  configMap:
-    name: hypertrace-graphql-service-config
-    data:
-      application.conf: |-
-        defaultTenantId = "__default"
-        gateway.service = {
-          host = localhost
-          port = 9001
-        }
-        attributes.service = {
-          host = localhost
-          port = 9001
-        }
   javaOpts: "-Xms128M -Xmx128M -XX:MaxDirectMemorySize=64M -XX:+ExitOnOutOfMemoryError"
   resources:
     requests:

--- a/kubernetes/clusters/standard/values.yaml
+++ b/kubernetes/clusters/standard/values.yaml
@@ -1,5 +1,4 @@
 zookeeper:
-  replicaCount: 3
   javaOpts: "-Xms320M -Xmx320M -XX:MaxDirectMemorySize=64M -XX:+ExitOnOutOfMemoryError"
   resources:
     requests:
@@ -10,7 +9,6 @@ zookeeper:
       memory: "512Mi"
 
 kafka:
-  replicaCount: 3
   javaOpts: "-Xms2G -Xmx2G -XX:MaxDirectMemorySize=128M -XX:+ExitOnOutOfMemoryError"
   resources:
     requests:
@@ -24,7 +22,6 @@ kafka:
     storage: "64Gi"
 
 schema-registry:
-  replicaCount: 2
   heapOptions: "-Xms128M -Xmx128M -XX:MaxDirectMemorySize=64M -XX:+ExitOnOutOfMemoryError"
   resources:
     requests:

--- a/kubernetes/config/hypertrace.properties
+++ b/kubernetes/config/hypertrace.properties
@@ -23,7 +23,7 @@ HT_KUBE_NAMESPACE=hypertrace
 # Installation time generally depends time to pull multiple hypertrace images from the repository.
 # Set it higher value if the connection is slower.
 # Units in minutes
-HT_INSTALL_TIMEOUT=30
+HT_INSTALL_TIMEOUT=15
 
 # Flag to debug installation issues
 # Allowed values: {true, false}

--- a/kubernetes/config/hypertrace.properties
+++ b/kubernetes/config/hypertrace.properties
@@ -23,7 +23,7 @@ HT_KUBE_NAMESPACE=hypertrace
 # Installation time generally depends time to pull multiple hypertrace images from the repository.
 # Set it higher value if the connection is slower.
 # Units in minutes
-HT_INSTALL_TIMEOUT=15
+HT_INSTALL_TIMEOUT=30
 
 # Flag to debug installation issues
 # Allowed values: {true, false}

--- a/kubernetes/data-services/Chart.yaml
+++ b/kubernetes/data-services/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     version: 0.1.5
   - name: pinot
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.2.3
+    version: 0.2.4
   - name: mongodb
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.0

--- a/kubernetes/platform-services/Chart.yaml
+++ b/kubernetes/platform-services/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: 0.1.23
   - name: raw-spans-grouper
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.23
+    version: 0.1.24
   - name: hypertrace-trace-enricher
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.26
@@ -43,7 +43,7 @@ dependencies:
     version: 0.46.0
   - name: hypertrace-graphql-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.3.6
+    version: 0.4.3
   - name: attribute-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.6.0

--- a/kubernetes/platform-services/Chart.yaml
+++ b/kubernetes/platform-services/Chart.yaml
@@ -40,22 +40,22 @@ dependencies:
     version: 0.1.22
   - name: hypertrace-ui
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.37.5
+    version: 0.46.0
   - name: hypertrace-graphql-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.3.1
+    version: 0.3.6
   - name: attribute-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.3.2
+    version: 0.6.0
   - name: gateway-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.24
+    version: 0.1.30
   - name: query-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.3.2
+    version: 0.3.3
   - name: entity-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.23
+    version: 0.1.27
   - name: hypertrace-federated-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.13

--- a/kubernetes/platform-services/Chart.yaml
+++ b/kubernetes/platform-services/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: 0.1.23
   - name: raw-spans-grouper
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.14
+    version: 0.1.23
   - name: hypertrace-trace-enricher
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.26

--- a/kubernetes/platform-services/values.yaml
+++ b/kubernetes/platform-services/values.yaml
@@ -99,6 +99,10 @@ raw-spans-grouper:
     limits:
       cpu: "1"
       memory: "1Gi"
+  volumeClaimTemplates:
+    name: hypertrace
+    storageClassName: hypertrace
+    storageRequestSize: 1Gi
   kafka-topic-creator:
     kafka:
       topics:


### PR DESCRIPTION
The last changes,
- removes usage of `federated service` in `dev` cluster mode, for local mode, use `docker-compose` setup. 
- fixes service selector associated with `federated service` 
- fixes raw-spans-grouper's stateful set requriments