### PR TITLE
Reduces Docker Hub usage by pulling examples from GitHub Container Registry

### DIFF
--- a/docker/docker-compose-zipkin-example.yml
+++ b/docker/docker-compose-zipkin-example.yml
@@ -3,7 +3,7 @@ services:
   # Generate traffic by hitting http://localhost:8081
   frontend:
     container_name: frontend
-    image: openzipkin/example-brave:armeria
+    image: ghcr.io/openzipkin/brave-example:armeria
     command: frontend
     environment: 
         - BRAVE_SUPPORTS_JOIN=false
@@ -14,7 +14,7 @@ services:
         condition: service_started
   backend:
     container_name: backend
-    image: openzipkin/example-brave:armeria
+    image: ghcr.io/openzipkin/brave-example:armeria
     command: backend
     environment: 
         - BRAVE_SUPPORTS_JOIN=false


### PR DESCRIPTION
The Zipkin example moved to GitHub Container Repository to prevent build
outages from the impending 1 Nov 100-200 pull limit/6hrs on Docker Hub's
registry.