### PR TITLE
chore: expose attribute service config to ingest

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,6 +58,8 @@ services:
       - REPLICATION_FACTOR=1
       - ENTITY_SERVICE_HOST_CONFIG=hypertrace
       - ENTITY_SERVICE_PORT_CONFIG=9001
+      - ATTRIBUTE_SERVICE_HOST_CONFIG=hypertrace
+      - ATTRIBUTE_SERVICE_PORT_CONFIG=9001
       - NUM_STREAM_THREADS=1
       - PRE_CREATE_TOPICS=true
       - PRODUCER_VALUE_SERDE=org.hypertrace.core.kafkastreams.framework.serdes.GenericAvroSerde


### PR DESCRIPTION
## Description
This exposes attribute service to the ingester image, which will use attributes to support https://github.com/hypertrace/hypertrace-ingester/pull/49


### Testing
Locally tested by building the linked ingester and spinning up a local HT cluster, verifying the new attribute-dependent functionality.

### Checklist:
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
