### PR TITLE
Updates zipkin example

### DIFF
--- a/docker/docker-compose-zipkin-example.yml
+++ b/docker/docker-compose-zipkin-example.yml
@@ -1,20 +1,23 @@
 version: '2.4'
+
+# BRAVE_EXAMPLE choices are listed here https://github.com/openzipkin/brave-example#example-projects
+
 services:
   # Generate traffic by hitting http://localhost:8081
   frontend:
     container_name: frontend
-    image: ghcr.io/openzipkin/brave-example:armeria
-    command: frontend
+    image: ghcr.io/openzipkin/brave-example:${BRAVE_EXAMPLE:-armeria}
+    entrypoint: start-frontend
     environment: 
         - BRAVE_SUPPORTS_JOIN=false
     ports:
       - 8081:8081
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
   backend:
     container_name: backend
-    image: ghcr.io/openzipkin/brave-example:armeria
-    command: backend
+    image: ghcr.io/openzipkin/brave-example:${BRAVE_EXAMPLE:-armeria}
+    entrypoint: start-backend
     environment: 
         - BRAVE_SUPPORTS_JOIN=false


### PR DESCRIPTION
## Description
This updates the zipkin example and also makes it easier for people to control what's running.

For example, they can set `BRAVE_EXAMPLE=webmvc25-jetty` to run a Java 1.6 instrumented app.

### Testing

```bash
BRAVE_EXAMPLE=webmvc25-jetty docker-compose -f docker-compose.yml -f docker-compose-zipkin-example.yml up
```

### Checklist:
N/A

### Documentation
N/A
