### PR TITLE
Updating alias for pinot's all-in-one deployment

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -100,6 +100,8 @@ services:
         # Usually, Pinot is distributed, and clients connect to the controller
         aliases:
           - pinot-controller
+          - pinot-server
+          - pinot-broker
     cpu_shares: 2048
     depends_on:
       kafka-zookeeper:


### PR DESCRIPTION
Based on my note here on the PR -  https://github.com/hypertrace/hypertrace-service/pull/51, we are using pinot-server health check in hypetrace service. Refer - https://github.com/hypertrace/hypertrace-service/pull/51#issuecomment-744181330
