### PR TITLE
updates helm chart and adds release notification slack bot

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -1,0 +1,18 @@
+on: 
+  release:
+    types:
+      - created
+      
+name: Slack Notification on Release
+jobs:
+  slackNotification:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK}}
+        SLACK_COLOR: '#3278BD'
+        SLACK_MESSAGE: 'New helm charts for Hypertrace have been released :rocket:'
+        SLACK_TITLE: Hypertrace has new release

--- a/kubernetes/data-services/Chart.yaml
+++ b/kubernetes/data-services/Chart.yaml
@@ -37,4 +37,4 @@ dependencies:
     version: 0.2.7
   - name: mongodb
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.0
+    version: 0.1.2

--- a/kubernetes/platform-services/Chart.yaml
+++ b/kubernetes/platform-services/Chart.yaml
@@ -28,35 +28,35 @@ dependencies:
     version: 0.1.7
   - name: span-normalizer
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.3.5
+    version: 0.4.2
   - name: raw-spans-grouper
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.3.5
+    version: 0.4.2
   - name: hypertrace-trace-enricher
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.3.5
+    version: 0.4.2
   - name: hypertrace-view-generator
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.3.5
+    version: 0.4.2
   - name: hypertrace-ui
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.68.3
+    version: 0.69.0
   - name: hypertrace-graphql-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.6.1
+    version: 0.7.1
   - name: attribute-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.8.7
+    version: 0.9.3
   - name: gateway-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.39
+    version: 0.1.45
   - name: query-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.5.1
+    version: 0.5.3
   - name: entity-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.4.4
+    version: 0.5.3
   - name: kafka-topic-creator
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.5
+    version: 0.1.7
     condition: kafka-topic-creator.enabled


### PR DESCRIPTION
## Description
This PR,
- updates helm charts
- adds release notification slack bot which will send updates on release channel in Hypertrace community slack. 


### Testing
Deployed and tested helm charts locally. 
<img width="2672" alt="Screenshot 2021-01-11 at 4 55 18 PM" src="https://user-images.githubusercontent.com/26570044/104176786-cdec2980-542d-11eb-9a58-8695598ae013.png">

Slack notification will look like below:
![image](https://user-images.githubusercontent.com/26570044/104177576-02141a00-542f-11eb-9a0e-4a3391aa2da3.png)



### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
