### PR TITLE
adds workflow to automate helm chart updates

### DIFF
--- a/.github/workflows/create-charts.sh
+++ b/.github/workflows/create-charts.sh
@@ -1,0 +1,83 @@
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+HELM_GCS_REPO='"https://storage.googleapis.com/hypertrace-helm-charts"'
+
+print_header() {
+    cat ".github/workflows/header.txt"
+    echo
+}
+
+update_data_services_charts() {
+        print_header
+        echo ""
+        echo 'dependencies:'
+        echo '  - name: kafka'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $kafka_version 
+        echo '  - name: zookeeper'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $zookeeper_version
+        echo '  - name: pinot'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $pinot_version 
+        echo '  - name: schema-registry'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $schema_registry_version
+        echo '  - name: mongodb'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $mongodb_version
+} 
+
+update_platform_services_charts() {
+        print_header
+        echo ""
+        echo 'dependencies:'
+        echo '  - name: hypertrace-oc-collector'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $hypertrace_oc_collector_version 
+        echo '  - name: span-normalizer'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $hypertrace_ingester_version
+        echo '  - name: raw-spans-grouper'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $hypertrace_ingester_version
+        echo '  - name: hypertrace-trace-enricher'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $hypertrace_ingester_version
+        echo '  - name: hypertrace-view-generator'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $hypertrace_ingester_version
+        echo '  - name: hypertrace-ui'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $hypertrace_ui_version 
+        echo '  - name: hypertrace-graphql-service'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $hypertrace_graphql_version
+        echo '  - name: attribute-service'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $attribute_service_version
+        echo '  - name: gateway-service'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $gateway_service_version
+        echo '  - name: query-service'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $query_service_version
+        echo '  - name: entity-service'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $entity_service_version
+        echo '  - name: kafka-topic-creator'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' 0.1.7
+        echo '    condition: kafka-topic-creator.enabled'
+} 
+
+
+if [ $1 == "data-services" ]; then
+    OUT_DIR="kubernetes/data-services"
+    charts_file="${OUT_DIR}/Chart.yaml"
+    update_data_services_charts > "${charts_file}"
+
+elif [ $1 == "platform-services" ]; then
+    OUT_DIR="kubernetes/platform-services"
+    charts_file="${OUT_DIR}/Chart.yaml"
+    update_platform_services_charts > "${charts_file}"
+fi

--- a/.github/workflows/header.txt
+++ b/.github/workflows/header.txt
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: hypertrace-services
+description: Hypertrace Distributed Tracing Platform - helm chart
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0

--- a/.github/workflows/pull-release.yml
+++ b/.github/workflows/pull-release.yml
@@ -2,7 +2,9 @@ name: get latest helm charts
 on:
   schedule:
     - cron: '00 06 * * 5' #every friday at 11:30 AM IST/ 6 AM UST
-
+  # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
+  # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow 
+  workflow_dispatch:
 
 jobs:
   get-latest-releases:

--- a/.github/workflows/pull-release.yml
+++ b/.github/workflows/pull-release.yml
@@ -129,7 +129,7 @@ jobs:
             helm-updates
             automated pr
             release
-          assignees: JBAhire, kotharironak, rish691
+          assignees: JBAhire
           reviewers: JBAhire, kotharironak, rish691
           team-reviewers: |
             owners

--- a/.github/workflows/pull-release.yml
+++ b/.github/workflows/pull-release.yml
@@ -1,0 +1,137 @@
+name: get latest helm charts
+on:
+  schedule:
+    - cron: '00 06 * * 5' #every friday at 11:30 AM IST/ 6 AM UST
+
+
+jobs:
+  get-latest-releases:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Get latest charts for kafka
+        id: kafka
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/kafka
+
+      - name: Get latest charts for zookeeper
+        id: zookeeper
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/zookeeper
+
+      - name: Get latest charts for pinot
+        id: pinot
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/pinot
+
+      - name: Get latest charts for schema-registry 
+        id: schema-registry
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/schema-registry
+
+      - name: Get latest charts for mongodb
+        id: mongodb
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/mongodb
+
+      - name: Get latest charts for oc-collector
+        id: opencensus-service
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/opencensus-service
+
+      - name: Get latest charts for ingester
+        id: hypertrace-ingester
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/hypertrace-ingester
+   
+      - name: Get latest charts for ui
+        id: hypertrace-ui
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/hypertrace-ui
+
+      - name: Get latest charts for graphql
+        id: hypertrace-graphql
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/hypertrace-graphql
+
+      - name: Get latest charts for attribute-service
+        id: attribute-service
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/attribute-service
+
+      - name: Get latest charts for gateway-service
+        id: gateway-service
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/gateway-service
+
+      - name: Get latest charts for query-service
+        id: query-service
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/query-service
+
+      - name: Get latest charts for entity-service
+        id: entity-service
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/entity-service
+
+      - uses: actions/checkout@v2
+
+      - name: Update data services charts
+        run: ./.github/workflows/create-charts.sh data-services
+        env: 
+          kafka_version: ${{ steps.kafka.outputs.tag }}
+          pinot_version: ${{ steps.pinot.outputs.tag }}
+          schema_registry_version: ${{ steps.schema-registry.outputs.tag }}
+          mongodb_version: ${{ steps.mongodb.outputs.tag }}
+          zookeeper_version: ${{ steps.zookeeper.outputs.tag }}
+      
+      - name: Update platform services charts
+        run: ./.github/workflows/create-charts.sh platform-services
+        env: 
+          hypertrace_oc_collector_version : ${{ steps.opencensus-service.outputs.tag }}
+          hypertrace_ingester_version: ${{ steps.hypertrace-ingester.outputs.tag }}
+          hypertrace_ui_version: ${{ steps.hypertrace-ui.outputs.tag }}
+          hypertrace_graphql_version: ${{ steps.hypertrace-graphql.outputs.tag }}
+          attribute_service_version: ${{ steps.attribute-service.outputs.tag }}
+          query_service_version: ${{ steps.query-service.outputs.tag }}
+          gateway_service_version: ${{ steps.gateway-service.outputs.tag }}
+          entity_service_version: ${{ steps.entity-service.outputs.tag }}
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.TOKEN }}
+          commit-message: Updates helm charts
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: update-helm-charts
+          delete-branch: true
+          title: '[chore] updates helm charts'
+          body: |
+            This PR,
+            - Updates helm charts as per the latest releases of all services. 
+            - **Note: This is auto-generated PR so please test and verify before merging.** 
+          labels: |
+            helm-updates
+            automated pr
+            release
+          assignees: JBAhire
+          reviewers: JBAhire
+          team-reviewers: |
+            owners
+            maintainers
+          draft: false

--- a/.github/workflows/pull-release.yml
+++ b/.github/workflows/pull-release.yml
@@ -129,8 +129,8 @@ jobs:
             helm-updates
             automated pr
             release
-          assignees: JBAhire
-          reviewers: JBAhire
+          assignees: JBAhire, kotharironak, rish691
+          reviewers: JBAhire, kotharironak, rish691
           team-reviewers: |
             owners
             maintainers


### PR DESCRIPTION
## Description
This PR, 
- adds workflow which pulls latest tags for all services and updates helm charts using script. 
- once charts are updates, it will automatically raise the PR. 
- This workflow runs on every Friday 6 AM UT/ 11:30 AM IST/ 10 PM PST (Thursday)

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
- https://github.com/peter-evans/create-pull-request
- https://github.com/marketplace/actions/find-latest-tag
