### PR TITLE
fixing streaming config due to name changes in latest charts

### DIFF
--- a/kubernetes/clusters/dev/values.yaml
+++ b/kubernetes/clusters/dev/values.yaml
@@ -188,10 +188,8 @@ raw-spans-grouper:
     initialDelaySeconds: 10
     periodSeconds: 5
   rawSpansGrouperConfig:
-    kafka:
-      streams:
-        config:
-          replicationFactor: 1
+    kafkaStreamsConfig:
+      replicationFactor: 1
     span:
       groupby:
         internal: 10


### PR DESCRIPTION
## Description
The `raw-spans-grouper` - one of the components of the ingestion pipeline was not coming up in the `helm` setup with the `dev` profile.

We were getting the below exception:
```
2021-01-19 06:53:35.475 [raw-spans-to-structured-traces-grouping-job-42d66b5b-1f55-4ff5-b31d-415a68329068-StreamThread-4] ERROR o.h.c.r.RawSpansGrouper - Thread=[raw-spans-to-structured-traces-grouping-job-42d66b5b-1f55-4ff5-b31d-415a68329068-StreamThread-4] encountered=[org.apache.kafka.streams.errors.StreamsException: Could not create topic raw-spans-to-structured-traces-grouping-job-trace-emit-trigger-store-changelog.
	at org.apache.kafka.streams.processor.internals.InternalTopicManager.makeReady(InternalTopicManager.java:148)
	at org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.prepareChangelogTopics(StreamsPartitionAssignor.java:691)
	at org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.assignTasksToClients(StreamsPartitionAssignor.java:717)
	at org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.assign(StreamsPartitionAssignor.java:382)
	at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.performAssignment(ConsumerCoordinator.java:589)
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.onJoinLeader(AbstractCoordinator.java:680)
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator.access$1100(AbstractCoordinator.java:111)
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$JoinGroupResponseHandler.handle(AbstractCoordinator.java:593)
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$JoinGroupResponseHandler.handle(AbstractCoordinator.java:556)
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$CoordinatorResponseHandler.onSuccess(AbstractCoordinator.java:1145)
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$CoordinatorResponseHandler.onSuccess(AbstractCoordinator.java:1120)
	at org.apache.kafka.clients.consumer.internals.RequestFuture$1.onSuccess(RequestFuture.java:206)
	at org.apache.kafka.clients.consumer.internals.RequestFuture.fireSuccess(RequestFuture.java:169)
	at org.apache.kafka.clients.consumer.internals.RequestFuture.complete(RequestFuture.java:129)
	at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient$RequestFutureCompletionHandler.fireCompletion(ConsumerNetworkClient.java:602)
	at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.firePendingCompletedRequests(ConsumerNetworkClient.java:412)
	at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.poll(ConsumerNetworkClient.java:297)
	at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.poll(ConsumerNetworkClient.java:236)
	at org.apache.kafka.clients.consumer.KafkaConsumer.pollForFetches(KafkaConsumer.java:1296)
	at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1237)
	at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1210)
	at org.apache.kafka.streams.processor.internals.StreamThread.pollRequests(StreamThread.java:766)
	at org.apache.kafka.streams.processor.internals.StreamThread.runOnce(StreamThread.java:624)
	at org.apache.kafka.streams.processor.internals.StreamThread.runLoop(StreamThread.java:551)
	at org.apache.kafka.streams.processor.internals.StreamThread.run(StreamThread.java:510)
Caused by: org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 3 larger than available brokers: 1.
```

The reason was the override helm keys were not matching with the one used in charts. This PR fixed it.

### Testing
Validated by running HT locally using `hypertrace.sh` script

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
None
