### PR TITLE
Adds collector and UI IP as env variables and explorer GraphQL tests

### DIFF
--- a/.github/graphql-e2e-tests/ingest-traces.sh
+++ b/.github/graphql-e2e-tests/ingest-traces.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-docker run -v $(PWD)/src/main/resources/traces/trace-1.json:/usr/src/jaeger2zipkin/trace-1.json jbahire/jaeger2zipkin trace-1.json http://host.docker.internal:9411/api/v2/spans
-docker run -v $(PWD)/src/main/resources/traces/trace-2.json:/usr/src/jaeger2zipkin/trace-2.json jbahire/jaeger2zipkin trace-2.json http://host.docker.internal:9411/api/v2/spans
-docker run -v $(PWD)/src/main/resources/traces/trace-3.json:/usr/src/jaeger2zipkin/trace-3.json jbahire/jaeger2zipkin trace-3.json http://host.docker.internal:9411/api/v2/spans
-docker run -v $(PWD)/src/main/resources/traces/trace-4.json:/usr/src/jaeger2zipkin/trace-4.json jbahire/jaeger2zipkin trace-4.json http://host.docker.internal:9411/api/v2/spans
+COLLECTOR_IP="$(kubectl get service hypertrace-oc-collector -n hypertrace | tr -s " " | cut -d' ' -f4 | grep -v "EXTERNAL-IP")"
+
+docker run -v $(pwd)/src/main/resources/traces/trace-1.json:/usr/src/jaeger2zipkin/trace-1.json jbahire/jaeger2zipkin trace-1.json http://$COLLECTOR_IP:9411/api/v2/spans
+docker run -v $(pwd)/src/main/resources/traces/trace-2.json:/usr/src/jaeger2zipkin/trace-2.json jbahire/jaeger2zipkin trace-2.json http://$COLLECTOR_IP:9411/api/v2/spans
+docker run -v $(pwd)/src/main/resources/traces/trace-3.json:/usr/src/jaeger2zipkin/trace-3.json jbahire/jaeger2zipkin trace-3.json http://$COLLECTOR_IP:9411/api/v2/spans
+docker run -v $(pwd)/src/main/resources/traces/trace-4.json:/usr/src/jaeger2zipkin/trace-4.json jbahire/jaeger2zipkin trace-4.json http://$COLLECTOR_IP:9411/api/v2/spans

--- a/.github/graphql-e2e-tests/src/main/java/org/hypertrace/e2etest/ApiTest.java
+++ b/.github/graphql-e2e-tests/src/main/java/org/hypertrace/e2etest/ApiTest.java
@@ -73,6 +73,12 @@ public class ApiTest {
   }
 
   @Test
+  public void explorerQuery_shouldSucceed() throws IOException {
+    Response response = executeGraphQLQuery("e2e-test/explorer.graphql");
+    assertResponseSanity(response, this::verifyNonZeroExplorerResults);
+  }
+
+  @Test
   public void traceIDQuery_shouldSucceed() throws IOException {
     Response response = executeGraphQLQuery("e2e-test/find-trace.graphql");
     assertResponseBasedOnTraceData(response, "1", "traces");
@@ -125,6 +131,13 @@ public class ApiTest {
 
   private void verifyNonZeroEntityResults(JsonNode dataJsonNode) {
     ArrayNode resultArray = (ArrayNode) dataJsonNode.findValue("entities").get("results");
+    if (resultArray.size() == 0) {
+      fail(String.format("Results array is empty. It should not be. %n %s", dataJsonNode));
+    }
+  }
+
+  private void verifyNonZeroExplorerResults(JsonNode dataJsonNode) {
+    ArrayNode resultArray = (ArrayNode) dataJsonNode.findValue("explore").get("results");
     if (resultArray.size() == 0) {
       fail(String.format("Results array is empty. It should not be. %n %s", dataJsonNode));
     }

--- a/.github/graphql-e2e-tests/src/main/java/org/hypertrace/e2etest/ApiTest.java
+++ b/.github/graphql-e2e-tests/src/main/java/org/hypertrace/e2etest/ApiTest.java
@@ -24,7 +24,8 @@ import org.junit.jupiter.api.Test;
 public class ApiTest {
   // The endpoint i.e host and port or the URL without the "/graphql" part
   private static final Integer DEFAULT_TIMERANGE_QUERY_TEST = 15;
-  private static String graphQLEndpoint = "http://localhost:2020";
+  private static String htuiIp = System.getenv("HTUI_IP");
+  private static String graphQLEndpoint = "http://"+htuiIp+":2020";
   private static String graphQLUrl;
   private static String graphQLResource = "/graphql";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -38,6 +39,7 @@ public class ApiTest {
       graphQLEndpoint = System.getenv("GRAPHQL_ENDPOINT");
     }
     graphQLUrl = graphQLEndpoint + graphQLResource;
+    System.out.println(graphQLUrl);
   }
 
   @Test

--- a/.github/graphql-e2e-tests/src/main/java/org/hypertrace/e2etest/ApiTest.java
+++ b/.github/graphql-e2e-tests/src/main/java/org/hypertrace/e2etest/ApiTest.java
@@ -39,7 +39,6 @@ public class ApiTest {
       graphQLEndpoint = System.getenv("GRAPHQL_ENDPOINT");
     }
     graphQLUrl = graphQLEndpoint + graphQLResource;
-    System.out.println(graphQLUrl);
   }
 
   @Test

--- a/.github/graphql-e2e-tests/src/main/resources/e2e-test/explorer.graphql
+++ b/.github/graphql-e2e-tests/src/main/resources/e2e-test/explorer.graphql
@@ -1,0 +1,22 @@
+{
+  explore(
+    context: API_TRACE
+    limit: 500
+    between: {
+      startTime: "2021-01-13T04:41:25.319Z"
+      endTime: "2021-01-20T04:41:25.319Z"
+    }
+    interval: { size: 30, units: MINUTES }
+  ) {
+    results {
+      __intervalStart: intervalStart
+      count_calls: selection(key: "calls", aggregation: COUNT) {
+        value
+        type
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}

--- a/.github/ui-e2e-tests/protractor.conf.js
+++ b/.github/ui-e2e-tests/protractor.conf.js
@@ -16,7 +16,7 @@ exports.config = {
     smoke: './src/**/*.smoke.spec.ts'
   },
   params: {
-    timeRange: '1w'
+    timeRange: '2w' 
   },
   jasmineNodeOpts: {
     showColors: true,

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -17,7 +17,7 @@ jobs:
           ref: parameterised-e2e
 
       - name: Start minikube
-        run: minikube start
+        run: minikube start --driver=none
       - name: Install Hypertrace
         working-directory: kubernetes
         run: |
@@ -44,8 +44,6 @@ jobs:
         run: |
           sleep 60 # you can decrease it but never increase it
           kubectl get services -n hypertrace
-          export COLLECTOR_IP="$(kubectl get service hypertrace-oc-collector -n hypertrace | tr -s " " | cut -d' ' -f4 | grep -v "EXTERNAL-IP")"
-          echo $COLLECTOR_IP
 
       - name: Ingest traces
         working-directory: ./.github/graphql-e2e-tests/
@@ -69,7 +67,7 @@ jobs:
       - name: Clean up
         if: ${{ always() }}
         run: |
-          minikube delete
+          minikube delete --all
 
       - name: Clean up
         if: ${{ always() }}

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -31,7 +31,7 @@ jobs:
           minikube logs
           minikube status
         
-      - name: show data
+      - name: Show Hypertrace deployment data
         run: |
           kubectl get pods -n hypertrace
           kubectl get services -n hypertrace
@@ -62,6 +62,7 @@ jobs:
           npm install 
           npm audit fix
           CHROMEDRIVER_RELEASE="$(google-chrome --product-version)" && npm run install-web-driver -- --versions.chrome=${CHROMEDRIVER_RELEASE}
+          export HTUI_IP=$(kubectl get service hypertrace-ui -n hypertrace -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
           npx protractor protractor.conf.js --suite smoke --baseUrl "http://${HTUI_IP}:2020"
 
       - name: Clean up

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -37,14 +37,20 @@ jobs:
           kubectl get pods -n hypertrace
       
       - name: Set up Minikube tunnel
-        run: minikube tunnel &> /dev/null &
+        run: |
+          mkdir /tmp/minikube-tunnel
+          minikube tunnel > /tmp/minikube-tunnel/a.log &
 
       - name: Print service info
-        run: kubectl get services -n hypertrace
+        run: |
+          kubectl get services -n hypertrace
+          export COLLECTOR_IP="$(kubectl get service hypertrace-oc-collector -n hypertrace | tr -s " " | cut -d' ' -f4 | grep -v "EXTERNAL-IP")"
+          echo $COLLECTOR_IP
 
       - name: Ingest traces
         working-directory: ./.github/graphql-e2e-tests/
-        run: ./ingest-traces.sh
+        run: | 
+          ./ingest-traces.sh
 
       - name: run GraphQL tests
         working-directory: ./.github/graphql-e2e-tests/

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -1,0 +1,72 @@
+name: e2e test
+on:
+  push:
+    ranches:
+      - parameterised-e2e
+  pull_request:
+    branches:
+      - update-helm-charts
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with: 
+          ref: parameterised-e2e
+
+      - name: Start minikube
+        run: minikube start
+      - name: Install Hypertrace
+        working-directory: kubernetes
+        run: ./hypertrace.sh install --clean
+
+      - name: Cluster Info
+        if: ${{ failure() }}
+        run: |
+          df -h
+          minikube logs
+          minikube status
+
+      - name: Waits for some stability
+        working-directory: kubernetes
+        run: |
+          sleep 120 # you can decrease it but never increase it
+          kubectl get pods -n hypertrace
+      - name: Set up Minikube tunnel
+        run: |
+          mkdir /tmp/minikube-tunnel
+          minikube tunnel > /tmp/minikube-tunnel/a.log &
+
+      - name: Ingest traces
+        working-directory: ./.github/graphql-e2e-tests/
+        run: ./ingest-traces.sh
+
+      - name: run GraphQL tests
+        working-directory: ./.github/graphql-e2e-tests/
+        run: |
+          export HTUI_IP=$(kubectl get service hypertrace-ui -n hypertrace -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          ./gradlew run
+
+      - name: run UI tests
+        working-directory: ./.github/ui-e2e-tests/
+        run: |
+          npm install 
+          npm audit fix
+          CHROMEDRIVER_RELEASE="$(google-chrome --product-version)" && npm run install-web-driver -- --versions.chrome=${CHROMEDRIVER_RELEASE}
+          npx protractor protractor.conf.js --suite smoke --baseUrl "http://${HTUI_IP}:2020"
+
+      - name: Clean up
+        if: ${{ always() }}
+        working-directory: kubernetes
+        run: |
+          ./hypertrace.sh uninstall
+          minikube delete
+
+      - name: Clean up
+        if: ${{ always() }}
+        run: rm -r -f hypertrace
+
+
+

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -23,7 +23,6 @@ jobs:
         run: |
           kubectl create ns hypertrace
           ./hypertrace.sh install --clean
-  
 
       - name: Cluster Info
         if: ${{ failure() }}
@@ -33,14 +32,15 @@ jobs:
           minikube status
 
       - name: Waits for some stability
-        working-directory: kubernetes
         run: |
-          sleep 120 # you can decrease it but never increase it
+          sleep 60 # you can decrease it but never increase it
           kubectl get pods -n hypertrace
+      
       - name: Set up Minikube tunnel
-        run: |
-          mkdir /tmp/minikube-tunnel
-          minikube tunnel > /tmp/minikube-tunnel/a.log &
+        run: minikube tunnel &> /dev/null &
+
+      - name: Print service info
+        run: kubectl get services -n hypertrace
 
       - name: Ingest traces
         working-directory: ./.github/graphql-e2e-tests/

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -74,8 +74,6 @@ jobs:
         if: ${{ always() }}
         working-directory: kubernetes
         run: ./hypertrace.sh uninstall
-          
-          minikube delete --all
 
       - name: Clean up minikube
         if: ${{ always() }}

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -20,7 +20,10 @@ jobs:
         run: minikube start
       - name: Install Hypertrace
         working-directory: kubernetes
-        run: ./hypertrace.sh install --clean
+        run: |
+          kubectl create ns hypertrace
+          ./hypertrace.sh install --clean
+  
 
       - name: Cluster Info
         if: ${{ failure() }}
@@ -59,9 +62,7 @@ jobs:
 
       - name: Clean up
         if: ${{ always() }}
-        working-directory: kubernetes
         run: |
-          ./hypertrace.sh uninstall
           minikube delete
 
       - name: Clean up

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Waits for some stability
         run: |
-          sleep 60 # you can decrease it but never increase it
+          sleep 40 # you can decrease it but never increase it
           kubectl get services -n hypertrace
 
       - name: Ingest traces
@@ -70,9 +70,17 @@ jobs:
           export HTUI_IP=$(kubectl get service hypertrace-ui -n hypertrace -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
           npx protractor protractor.conf.js --suite smoke --baseUrl "http://${HTUI_IP}:2020"
 
-      - name: Clean up
+      - name: Uninstall Hypertrace
         if: ${{ always() }}
-        run: |
+        working-directory: kubernetes
+        run: ./hypertrace.sh uninstall
+          
+          minikube delete --all
+
+      - name: Clean up minikube
+        if: ${{ always() }}
+        run: | 
+          minikube stop
           minikube delete --all
 
       - name: Clean up

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -1,7 +1,7 @@
-name: e2e test
+name: hypertrace CD
 on:
   push:
-    ranches:
+    branches:
       - parameterised-e2e
   pull_request:
     branches:

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -50,6 +50,11 @@ jobs:
         run: | 
           ./ingest-traces.sh
 
+      - name: Waits for some stability
+        run: |
+          sleep 40 # you can decrease it but never increase it
+          kubectl get services -n hypertrace
+
       - name: run GraphQL tests
         working-directory: ./.github/graphql-e2e-tests/
         run: |

--- a/.github/workflows/hypertrace-cd.yml
+++ b/.github/workflows/hypertrace-cd.yml
@@ -30,19 +30,19 @@ jobs:
           df -h
           minikube logs
           minikube status
+        
+      - name: show data
+        run: |
+          kubectl get pods -n hypertrace
+          kubectl get services -n hypertrace
+
+      - name: Set up Minikube tunnel
+        run: |
+          minikube tunnel > /tmp/minikube-tunnel/a.log &
 
       - name: Waits for some stability
         run: |
           sleep 60 # you can decrease it but never increase it
-          kubectl get pods -n hypertrace
-      
-      - name: Set up Minikube tunnel
-        run: |
-          mkdir /tmp/minikube-tunnel
-          minikube tunnel > /tmp/minikube-tunnel/a.log &
-
-      - name: Print service info
-        run: |
           kubectl get services -n hypertrace
           export COLLECTOR_IP="$(kubectl get service hypertrace-oc-collector -n hypertrace | tr -s " " | cut -d' ' -f4 | grep -v "EXTERNAL-IP")"
           echo $COLLECTOR_IP

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea/
 *.idea
+/.github/ui-e2e-tests/node_modules/
+/.github/graphql-e2e-tests/.gradle/
+/.github/graphql-e2e-tests/build/

--- a/kubernetes/config/hypertrace.properties
+++ b/kubernetes/config/hypertrace.properties
@@ -10,11 +10,11 @@ HT_PROFILE=dev
 
 # Cloud provider name
 # Allowed values: {docker-desktop, minikube, microk8s, gcp, aws}
-HT_ENV=docker-desktop
+HT_ENV=minikube
 
 # Kubernetes context to deploy hypertrace
 # This uses your current namespace by default. if you want to specify some particular namespace you can add it here. 
-HT_KUBE_CONTEXT= 
+HT_KUBE_CONTEXT=minikube
 
 # Kubernetes namespace to deploy hypertrace
 HT_KUBE_NAMESPACE=hypertrace

--- a/kubernetes/hypertrace.sh
+++ b/kubernetes/hypertrace.sh
@@ -126,24 +126,8 @@ case "$subcommand" in
 
   uninstall)
     echo "[INFO] Uninstalling Hypertrace deletes the hypertrace namespace and deletes any data stored."
-    echo "Choose an option to continue"
-
-    select yn in "Yes" "No"; do
-        case $yn in
-            Yes )
-              clean
-              kubectl delete ns ${HT_KUBE_NAMESPACE} ${KUBE_FLAGS}
-              echo "[INFO] Uninstall successful."
-              break;;
-
-            No )
-              echo "[INFO] Uninstall cancelled."
-              exit;;
-        esac
-    done
-    ;;
-  *)
-    echo "[ERROR] Unknown command: ${subcommand}"
-    usage
+    clean
+    kubectl delete ns ${HT_KUBE_NAMESPACE} ${KUBE_FLAGS}
+    echo "[INFO] Uninstall successful."
     ;;
 esac


### PR DESCRIPTION
## Description
This PR, 
- adds collector and UI IP as env variables so can be re-used in various step in CD as well as can be configured easily without code change. 
- Adds GraphQL test for explorer. 
- changing defaults of `HT_ENV` and `HT_KUBE_CONTEXT` to minikube. In case of other deployments, users have to change them manually as mentioned in documentation. 


### Testing
<img width="1012" alt="Screenshot 2021-01-20 at 11 14 58 AM" src="https://user-images.githubusercontent.com/26570044/105132319-bd643f00-5b10-11eb-91e9-e3143a71fdbd.png">


### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

