### PR TITLE
chore: add config service and update releases

### DIFF
--- a/.github/workflows/create-charts.sh
+++ b/.github/workflows/create-charts.sh
@@ -66,6 +66,9 @@ update_platform_services_charts() {
         echo '  - name: entity-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $entity_service_version
+        echo '  - name: config-service'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $config_service_version
         echo '  - name: kafka-topic-creator'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' 0.1.7

--- a/.github/workflows/pull-release.yml
+++ b/.github/workflows/pull-release.yml
@@ -88,6 +88,12 @@ jobs:
         with:
           repository: hypertrace/entity-service
 
+      - name: Get latest charts for config-service
+        id: config-service
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/config-service
+
       - uses: actions/checkout@v2
 
       - name: Update data services charts
@@ -114,6 +120,7 @@ jobs:
           query_service_version: ${{ steps.query-service.outputs.tag }}
           gateway_service_version: ${{ steps.gateway-service.outputs.tag }}
           entity_service_version: ${{ steps.entity-service.outputs.tag }}
+          config_service_version: ${{ steps.config-service.outputs.tag }}
 
       - name: Create Pull Request
         id: cpr

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Released versions of Docker images for various Hypertrace components are availab
 * [Query Service](https://github.com/hypertrace/query-service)
 * [Entity Service](https://github.com/hypertrace/entity-service)
 * [Attribute Service](https://github.com/hypertrace/attribute-service)
+* [Config Service](https://github.com/hypertrace/config-service)
 
 ### UI
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - ENTITY_SERVICE_PORT_CONFIG=9001
       - ATTRIBUTE_SERVICE_HOST_CONFIG=hypertrace
       - ATTRIBUTE_SERVICE_PORT_CONFIG=9001
+      - CONFIG_SERVICE_HOST_CONFIG=hypertrace
+      - CONFIG_SERVICE_PORT_CONFIG=9001
       - NUM_STREAM_THREADS=1
       - PRE_CREATE_TOPICS=true
       - PRODUCER_VALUE_SERDE=org.hypertrace.core.kafkastreams.framework.serdes.GenericAvroSerde

--- a/kubernetes/clusters/standard/values.yaml
+++ b/kubernetes/clusters/standard/values.yaml
@@ -195,6 +195,15 @@ query-service:
       cpu: "1"
       memory: "512Mi"
 
+config-service:
+  resources:
+    requests:
+      cpu: "0.1"
+      memory: "256Mi"
+    limits:
+      cpu: "0.5"
+      memory: "512Mi"
+
 hypertrace-graphql-service:
   javaOpts: "-Xms512M -Xmx768M"
   serviceConfig:

--- a/kubernetes/platform-services/Chart.yaml
+++ b/kubernetes/platform-services/Chart.yaml
@@ -28,34 +28,37 @@ dependencies:
     version: 0.1.7
   - name: span-normalizer
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.4.2
+    version: 0.4.3
   - name: raw-spans-grouper
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.4.2
+    version: 0.4.3
   - name: hypertrace-trace-enricher
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.4.2
+    version: 0.4.3
   - name: hypertrace-view-generator
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.4.2
+    version: 0.4.3
   - name: hypertrace-ui
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.69.0
   - name: hypertrace-graphql-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.7.1
+    version: 0.7.3
   - name: attribute-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.9.3
   - name: gateway-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.1.47
+    version: 0.1.52
   - name: query-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.5.3
   - name: entity-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.5.4
+  - name: config-service
+    repository: "https://storage.googleapis.com/hypertrace-helm-charts"
+    version: 0.1.0
   - name: kafka-topic-creator
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.7

--- a/kubernetes/platform-services/values.yaml
+++ b/kubernetes/platform-services/values.yaml
@@ -245,10 +245,10 @@ attribute-service:
   resources:
     requests:
       cpu: "0.25"
-      memory: "512Mi"
+      memory: "128Mi"
     limits:
       cpu: "0.5"
-      memory: "512Mi"
+      memory: "256Mi"
 query-service:
   resources:
     requests:
@@ -260,6 +260,14 @@ query-service:
   queryServiceConfig:
     data:
       zookeeperConnectionString: zookeeper:2181/pinot/hypertrace-views
+config-service:
+  resources:
+    requests:
+      cpu: "0.1"
+      memory: "128Mi"
+    limits:
+      cpu: "0.25"
+      memory: "256Mi"
 hypertrace-graphql-service:
   javaOpts: "-Xms128M -Xmx256M"
   serviceConfig:
@@ -279,11 +287,11 @@ hypertrace-ui:
     graphqlRedirectEnabled: true
   resources:
     requests:
-      cpu: "0.25"
-      memory: "320Mi"
+      cpu: "0.1"
+      memory: "128Mi"
     limits:
-      cpu: "0.5"
-      memory: "512Mi"
+      cpu: "0.25"
+      memory: "256Mi"
 
 kafka-topic-creator:
   enabled: false


### PR DESCRIPTION
## Description
This change adds config service to both docker-compose and k8s deployments, as described in https://github.com/hypertrace/hypertrace-service/pull/60#issuecomment-763726172


### Testing
Verified both deployment variants locally, making sure to read + write to config service.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
