### PR TITLE
fix: helm values for hypertrace-view-generator

### DIFF
--- a/kubernetes/clusters/dev/values.yaml
+++ b/kubernetes/clusters/dev/values.yaml
@@ -218,8 +218,8 @@ hypertrace-view-generator:
   viewGeneratorGroups:
     all-views-generator:
       generator:
+        replicaCount: 1
         resources:
-          replicaCount: 1
           limits:
             cpu: 1
             memory: 1.5Gi


### PR DESCRIPTION
## Description
There was an issue with helm values for hypertrace-view-generator. as per the helm chart [here](https://github.com/hypertrace/hypertrace-ingester/blob/d12c5b94d709f72e7ca66c269c08968320223569/hypertrace-view-generator/helm/values.yaml) `replicaCount` should be under generator but it was placed under resources. This was causing install failure. 

This PR resolves that. 

### Testing
tested with EKS setup

<img width="1781" alt="Screenshot 2021-02-04 at 3 28 26 PM" src="https://user-images.githubusercontent.com/26570044/106876375-a2dbb980-66fd-11eb-96e5-97a9a2128deb.png">


### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

