### PR TITLE
feat: add macro services for query layer

### DIFF
--- a/.github/workflows/create-charts.sh
+++ b/.github/workflows/create-charts.sh
@@ -65,26 +65,39 @@ update_platform_services_charts() {
         echo '  - name: hypertrace-graphql-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $hypertrace_graphql_version
-        echo '  - name: attribute-service'
-        echo '    repository:' $HELM_GCS_REPO
-        echo '    version:' $attribute_service_version
         echo '  - name: gateway-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $gateway_service_version
+        echo '    condition: merge-query-services.enabled'
         echo '  - name: query-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $query_service_version
+        echo '    condition: merge-query-services.enabled'
         echo '  - name: entity-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $entity_service_version
+        echo '    condition: merge-query-services.enabled'
+        echo '  - name: attribute-service'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $attribute_service_version
+        echo '    condition: merge-query-services.enabled'
         echo '  - name: config-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $config_service_version
+        echo '    condition: merge-query-services.enabled'
+        echo '  - name: hypertrace-data-config-service'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $hypertrace_service_version
+        echo '    condition: merge-query-services.enabled'
+        echo '  - name: hypertrace-data-query-service'
+        echo '    repository:' $HELM_GCS_REPO
+        echo '    version:' $hypertrace_service_version
+        echo '    condition: merge-query-services.enabled' 
         echo '  - name: kafka-topic-creator'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' 0.1.7
         echo '    condition: kafka-topic-creator.enabled'
-} 
+}
 
 write_to_tmp_source() {
         echo 'attribute-service:'$attribute_service_version

--- a/.github/workflows/create-charts.sh
+++ b/.github/workflows/create-charts.sh
@@ -68,23 +68,23 @@ update_platform_services_charts() {
         echo '  - name: gateway-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $gateway_service_version
-        echo '    condition: merge-query-services.enabled'
+        echo '    condition: merge-query-services.disabled'
         echo '  - name: query-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $query_service_version
-        echo '    condition: merge-query-services.enabled'
+        echo '    condition: merge-query-services.disabled'
         echo '  - name: entity-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $entity_service_version
-        echo '    condition: merge-query-services.enabled'
+        echo '    condition: merge-query-services.disabled'
         echo '  - name: attribute-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $attribute_service_version
-        echo '    condition: merge-query-services.enabled'
+        echo '    condition: merge-query-services.disabled'
         echo '  - name: config-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $config_service_version
-        echo '    condition: merge-query-services.enabled'
+        echo '    condition: merge-query-services.disabled'
         echo '  - name: hypertrace-data-config-service'
         echo '    repository:' $HELM_GCS_REPO
         echo '    version:' $hypertrace_service_version

--- a/.github/workflows/pull-release.yml
+++ b/.github/workflows/pull-release.yml
@@ -99,6 +99,12 @@ jobs:
         uses: oprypin/find-latest-tag@v1
         with:
           repository: hypertrace/hypertrace
+      
+      - name: Get latest charts for hypertrace-service
+        id: hypertrace
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: hypertrace/hypertrace-service
 
       - uses: actions/checkout@v2
 
@@ -132,6 +138,7 @@ jobs:
           gateway_service_version: ${{ steps.gateway-service.outputs.tag }}
           entity_service_version: ${{ steps.entity-service.outputs.tag }}
           config_service_version: ${{ steps.config-service.outputs.tag }}
+          hypertrace_service_version: ${{ steps.hypertrace-service.outputs.tag }}
 
       - name: update release notes
         run: |

--- a/.github/workflows/pull-release.yml
+++ b/.github/workflows/pull-release.yml
@@ -1,5 +1,8 @@
 name: get latest helm charts
 on:
+  push:
+    branches:
+      - main  
   schedule:
     - cron: '00 06 * * 5' #every friday at 11:30 AM IST/ 6 AM UST
   # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
@@ -101,7 +104,7 @@ jobs:
           repository: hypertrace/hypertrace
       
       - name: Get latest charts for hypertrace-service
-        id: hypertrace
+        id: hypertrace-service
         uses: oprypin/find-latest-tag@v1
         with:
           repository: hypertrace/hypertrace-service
@@ -169,29 +172,29 @@ jobs:
           entity_service_version: ${{ steps.entity-service.outputs.tag }}
           config_service_version: ${{ steps.config-service.outputs.tag }}
 
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.TOKEN }}
-          commit-message: Updates helm charts
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          signoff: false
-          branch: update-helm-charts
-          delete-branch: true
-          title: 'chore: updates helm charts'
-          body: |
-            This PR,
-            - Updates helm charts as per the latest releases of all services. 
-            - **Note: This is auto-generated PR so please test and verify before merging.** 
-          labels: |
-            helm-updates
-            automated pr
-            release
-          assignees: JBAhire
-          reviewers: kotharironak, rish691
-          team-reviewers: |
-            owners
-            maintainers
-          draft: false
+      # - name: Create Pull Request
+      #   id: cpr
+      #   uses: peter-evans/create-pull-request@v3
+      #   with:
+      #     token: ${{ secrets.TOKEN }}
+      #     commit-message: Updates helm charts
+      #     committer: GitHub <noreply@github.com>
+      #     author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+      #     signoff: false
+      #     branch: update-helm-charts
+      #     delete-branch: true
+      #     title: 'chore: updates helm charts'
+      #     body: |
+      #       This PR,
+      #       - Updates helm charts as per the latest releases of all services. 
+      #       - **Note: This is auto-generated PR so please test and verify before merging.** 
+      #     labels: |
+      #       helm-updates
+      #       automated pr
+      #       release
+      #     assignees: JBAhire
+      #     reviewers: kotharironak, rish691
+      #     team-reviewers: |
+      #       owners
+      #       maintainers
+      #     draft: false

--- a/.github/workflows/pull-release.yml
+++ b/.github/workflows/pull-release.yml
@@ -1,8 +1,5 @@
 name: get latest helm charts
 on:
-  push:
-    branches:
-      - main  
   schedule:
     - cron: '00 06 * * 5' #every friday at 11:30 AM IST/ 6 AM UST
   # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.

--- a/.github/workflows/pull-release.yml
+++ b/.github/workflows/pull-release.yml
@@ -172,29 +172,29 @@ jobs:
           entity_service_version: ${{ steps.entity-service.outputs.tag }}
           config_service_version: ${{ steps.config-service.outputs.tag }}
 
-      # - name: Create Pull Request
-      #   id: cpr
-      #   uses: peter-evans/create-pull-request@v3
-      #   with:
-      #     token: ${{ secrets.TOKEN }}
-      #     commit-message: Updates helm charts
-      #     committer: GitHub <noreply@github.com>
-      #     author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-      #     signoff: false
-      #     branch: update-helm-charts
-      #     delete-branch: true
-      #     title: 'chore: updates helm charts'
-      #     body: |
-      #       This PR,
-      #       - Updates helm charts as per the latest releases of all services. 
-      #       - **Note: This is auto-generated PR so please test and verify before merging.** 
-      #     labels: |
-      #       helm-updates
-      #       automated pr
-      #       release
-      #     assignees: JBAhire
-      #     reviewers: kotharironak, rish691
-      #     team-reviewers: |
-      #       owners
-      #       maintainers
-      #     draft: false
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.TOKEN }}
+          commit-message: Updates helm charts
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: update-helm-charts
+          delete-branch: true
+          title: 'chore: updates helm charts'
+          body: |
+            This PR,
+            - Updates helm charts as per the latest releases of all services. 
+            - **Note: This is auto-generated PR so please test and verify before merging.** 
+          labels: |
+            helm-updates
+            automated pr
+            release
+          assignees: JBAhire
+          reviewers: kotharironak, rish691
+          team-reviewers: |
+            owners
+            maintainers
+          draft: false

--- a/kubernetes/platform-services/Chart.yaml
+++ b/kubernetes/platform-services/Chart.yaml
@@ -28,37 +28,50 @@ dependencies:
     version: 0.1.7
   - name: span-normalizer
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.5.3
+    version: 0.5.4
   - name: raw-spans-grouper
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.5.3
+    version: 0.5.4
   - name: hypertrace-trace-enricher
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.5.3
+    version: 0.5.4
   - name: hypertrace-view-generator
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.5.3
+    version: 0.5.4
   - name: hypertrace-ui
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.69.3
   - name: hypertrace-graphql-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.7.3
-  - name: attribute-service
-    repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.9.3
   - name: gateway-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.54
+    condition: merge-query-services.disabled
   - name: query-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.5.4
+    condition: merge-query-services.disabled
+  - name: attribute-service
+    repository: "https://storage.googleapis.com/hypertrace-helm-charts"
+    version: 0.9.3  
+    condition: merge-query-services.disabled
   - name: entity-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.5.7
+    condition: merge-query-services.disabled
   - name: config-service
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.1
+    condition: merge-query-services.disabled
+  - name: hypertrace-data-config-service
+    repository: "https://storage.googleapis.com/hypertrace-helm-charts"
+    version: 0.1.21
+    condition: merge-query-services.enabled
+  - name: hypertrace-data-query-service
+    repository: "https://storage.googleapis.com/hypertrace-helm-charts"
+    version: 0.1.21   
+    condition: merge-query-services.enabled
   - name: kafka-topic-creator
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
     version: 0.1.7

--- a/kubernetes/platform-services/postgres/values.yaml
+++ b/kubernetes/platform-services/postgres/values.yaml
@@ -17,3 +17,17 @@ config-service:
       host: postgres
       port: 5432
       url: ""
+
+hypertrace-data-config-service:
+  entityServiceConfig:
+    dataStoreType: "postgres"
+  attributeServiceConfig:
+    dataStoreType: "postgres"    
+  configServiceConfig:
+    dataStoreType: "postgres"
+    postgres:
+      host: postgres
+      port: 5432
+      url: ""
+  config-bootstrapper:
+    dataStoreType: "postgres"

--- a/kubernetes/platform-services/values.yaml
+++ b/kubernetes/platform-services/values.yaml
@@ -1,3 +1,26 @@
+merge-query-services: 
+  enabled: false
+  disabled: true
+
+# when merge-query-services.enabled, set 
+# entityServiceHost: &entityServiceHost hypertrace-data-config-service
+# entityServicePort: &entityServicePort 9012 
+# attributeServiceHost: &attributeServiceHost hypertrace-data-config-service
+# attributeServicePort: &attributeServicePort 9012
+# configServiceHost: &configServiceHost hypertrace-data-config-service
+# configServicePort: &configServicePort 9012
+# gatewayServiceHost: &gatewayServiceHost hypertrace-data-query-service
+# gatewayServicePort: &gatewayServicePort 9001
+
+entityServiceHost: &entityServiceHost entity-service 
+entityServicePort: &entityServicePort 50061 
+attributeServiceHost: &attributeServiceHost attribute-service
+attributeServicePort: &attributeServicePort 9012
+configServiceHost: &configServiceHost config-service
+configServicePort: &configServicePort 50101
+gatewayServiceHost: &gatewayServiceHost gateway-service
+gatewayServicePort: &gatewayServicePort 9001
+
 hypertrace-oc-collector:
   resources:
     requests:
@@ -114,6 +137,13 @@ raw-spans-grouper:
             - retention.ms=21600000
 
 hypertrace-trace-enricher:
+  traceEnricherConfig:
+    entityServiceHost: *entityServiceHost 
+    entityServicePort: *entityServicePort
+    attributeServiceHost: *attributeServiceHost
+    attributeServicePort: *attributeServicePort
+    configServiceHost: *configServiceHost
+    configServicePort: *configServicePort 
   javaOpts: "-Xms512M -Xmx768M"
   resources:
     requests:
@@ -122,6 +152,7 @@ hypertrace-trace-enricher:
     limits:
       cpu: "1"
       memory: "1Gi"
+
   kafka-topic-creator:
     enabled: true
     kafka:
@@ -175,9 +206,6 @@ hypertrace-view-generator:
             - retention.bytes=1073741824
             - retention.ms=21600000
 
-hypertrace-federated-service:
-  enabled: false
-
 gateway-service:
   resources:
     requests:
@@ -225,11 +253,61 @@ config-service:
     limits:
       cpu: "0.25"
       memory: "256Mi"
+      
+hypertrace-data-query-service:
+  queryServiceConfig:
+    data:
+      attributeClient:
+        host: hypertrace-data-config-service
+        port: 9012
+  gatewayServiceConfig:
+    data:
+      application.conf: |-
+        query.service.config = {
+          host = localhost
+          port = 9001
+        }
+        entity.service.config = {
+          host = hypertrace-data-config-service
+          port = 9012
+        }
+        attributes.service.config = {
+          host = hypertrace-data-config-service
+          port = 9012
+        }
+  resources:
+    requests:
+      cpu: "0.25"
+      memory: "512Mi"
+    limits:
+      cpu: "0.5"
+      memory: "512Mi"
+
+hypertrace-data-config-service:
+  resources:
+    requests:
+      cpu: "0.25"
+      memory: "512Mi"
+    limits:
+      cpu: "0.5"
+      memory: "512Mi"       
 
 hypertrace-graphql-service:
   javaOpts: "-Xms128M -Xmx256M"
   serviceConfig:
     defaultTenantId: "__default"
+    gatewayService:
+      host: *gatewayServiceHost
+      port: *gatewayServicePort
+    attributeService:
+      host: *attributeServiceHost
+      port: *attributeServicePort
+    entityService:
+      host: *entityServiceHost
+      port: *entityServicePort
+    configService:
+      host: *configServiceHost
+      port: *configServicePort
   resources:
     requests:
       cpu: "0.25"


### PR DESCRIPTION
Tested automated pr creation. This pr https://github.com/rish691/hypertrace-1/pull/2 got created.
Currently not adding hypertrace-data-query & hypertrace-data-config service to release notes & compatibility matrix. 

Verified by running e2e test locally [with query services merged]