### PR TITLE
chore: cleanup package.json for ui e2e tests

### DIFF
--- a/.github/ui-e2e-tests/package.json
+++ b/.github/ui-e2e-tests/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@traceable/e2e",
+  "name": "@hypertrace/e2e",
   "version": "0.0.0",
-  "description": "E2E Tests for Traceable UI App",
+  "description": "E2E Tests for hypertrace UI App",
   "author": "",
   "license": "MIT",
   "scripts": {
     "tsc": "tsc",
-    "install-web-driver": "webdriver-manager clean && webdriver-manager update",
+    "install-web-driver": "webdriver-manager clean && webdriver-manager update --gecko false",
     "test": "protractor protractor.conf.js --suite smoke"
   },
   "dependencies": {


### PR DESCRIPTION
## Description
- removes reference to non-hypertrace nomenclature. 
- disables gecko by default as it's causing chromedriver install failure sometimes. 

Thanks to @skjindal93 for pointing out gecko thing. 

### Testing
tested this locally

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules


