### PR TITLE
fix: replaces RE with yaml parsing for hook based manifest creation

### DIFF
--- a/kubernetes/hypertrace.sh
+++ b/kubernetes/hypertrace.sh
@@ -122,18 +122,18 @@ fi
 
 function create_helm_manifests_for_services(){
   if [ $HT_DATA_STORE == "postgres" ]; then
-      helm install --dry-run hypertrace-$1 ${HYPERTRACE_HOME}/$1/charts/$OPTION_ARG -f ${HYPERTRACE_HOME}/$1/values.yaml -f ${HYPERTRACE_HOME}/$1/postgres/values.yaml -f ${HYPERTRACE_HOME}/clusters/$HT_PROFILE/values.yaml -n hypertrace --set htEnv=${HT_ENV} > $2
+      helm install --dry-run hypertrace-$1 ${HYPERTRACE_HOME}/$1/charts/$OPTION_ARG -f ${HYPERTRACE_HOME}/$1/values.yaml -f ${HYPERTRACE_HOME}/$1/postgres/values.yaml -f ${HYPERTRACE_HOME}/clusters/$HT_PROFILE/values.yaml -n ${HT_KUBE_NAMESPACE} --set htEnv=${HT_ENV} > $2
   else
-      helm install --dry-run hypertrace-$1 ${HYPERTRACE_HOME}/$1/charts/$OPTION_ARG -f ${HYPERTRACE_HOME}/$1/values.yaml -f ${HYPERTRACE_HOME}/clusters/$HT_PROFILE/values.yaml -n hypertrace --set htEnv=${HT_ENV} > $2
+      helm install --dry-run hypertrace-$1 ${HYPERTRACE_HOME}/$1/charts/$OPTION_ARG -f ${HYPERTRACE_HOME}/$1/values.yaml -f ${HYPERTRACE_HOME}/clusters/$HT_PROFILE/values.yaml -n ${HT_KUBE_NAMESPACE} --set htEnv=${HT_ENV} > $2
   fi
 }
 
 function create_helm_templates(){
   helm dependency update ${HYPERTRACE_HOME}/$1 ${HELM_FLAGS}
   if [ $HT_DATA_STORE == "postgres" ]; then
-    helm install --dry-run hypertrace-$1 ${HYPERTRACE_HOME}/$1 -f ${HYPERTRACE_HOME}/$1/values.yaml -f ${HYPERTRACE_HOME}/$1/postgres/values.yaml -f ${HYPERTRACE_HOME}/clusters/$HT_PROFILE/values.yaml -n hypertrace --set htEnv=${HT_ENV} > $2
+    helm install --dry-run hypertrace-$1 ${HYPERTRACE_HOME}/$1 -f ${HYPERTRACE_HOME}/$1/values.yaml -f ${HYPERTRACE_HOME}/$1/postgres/values.yaml -f ${HYPERTRACE_HOME}/clusters/$HT_PROFILE/values.yaml -n ${HT_KUBE_NAMESPACE} --set htEnv=${HT_ENV} > $2
   else
-    helm install --dry-run hypertrace-$1 ${HYPERTRACE_HOME}/$1 -f ${HYPERTRACE_HOME}/$1/values.yaml -f ${HYPERTRACE_HOME}/clusters/$HT_PROFILE/values.yaml -n hypertrace --set htEnv=${HT_ENV} > $2
+    helm install --dry-run hypertrace-$1 ${HYPERTRACE_HOME}/$1 -f ${HYPERTRACE_HOME}/$1/values.yaml -f ${HYPERTRACE_HOME}/clusters/$HT_PROFILE/values.yaml -n ${HT_KUBE_NAMESPACE} --set htEnv=${HT_ENV} > $2
   fi
 }
 subcommand=$1; shift
@@ -166,13 +166,13 @@ case "$subcommand" in
       mkdir ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/pre-install-tasks/
       create_helm_templates platform-services ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/manifests.yaml
       echo "[INFO] creating helm deployment template for pre-install tasks"
-      python pre_post_install_task_generator.py pre ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/manifests.yaml ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/pre-install-tasks/pre-install-manifests.yaml
+      python pre_post_install_task_generator.py pre-install ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/manifests.yaml ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/pre-install-tasks/pre-install-manifests.yaml
       echo "[INFO] pre-install task manifests are generated at: " ${HYPERTRACE_HOME}"/platform-services/helm-deployment-templates/pre-install-tasks/pre-install-manifests.yaml"
     elif [[ "$OPTION" == "--deps" && "$OPTION_ARG" == "post-install-tasks" ]]; then
       mkdir ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/post-install-tasks/
       create_helm_templates platform-services ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/manifests.yaml
       echo "[INFO] creating helm deployment template for post-install tasks"
-      python pre_post_install_task_generator.py post ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/manifests.yaml ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/post-install-tasks/post-install-manifests.yaml
+      python pre_post_install_task_generator.py post-install ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/manifests.yaml ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/post-install-tasks/post-install-manifests.yaml
       echo "[INFO] post-install task manifests are generated at: " ${HYPERTRACE_HOME}"/platform-services/helm-deployment-templates/post-install-tasks/post-install-manifests.yaml"
     fi
 
@@ -180,7 +180,6 @@ case "$subcommand" in
       echo "[INFO] creating helm deployment template for hypertrace data services."
       create_helm_templates data-services ${HYPERTRACE_HOME}/data-services/helm-deployment-templates/manifests.yaml
       echo "[INFO] data services manifests are generated at: " ${HYPERTRACE_HOME}"/data-services/helm-deployment-templates/manifests.yaml"
-      echo "[INFO] creating helm deployment template for hypertrace platform services."
       echo "[INFO] creating helm deployment template for hypertrace platform services."
       create_helm_templates platform-services ${HYPERTRACE_HOME}/platform-services/helm-deployment-templates/manifests.yaml
       echo "[INFO] platform services manifests are generated at: " ${HYPERTRACE_HOME}"/platform-services/helm-deployment-templates/manifests.yaml"

--- a/kubernetes/pre_post_install_task_generator.py
+++ b/kubernetes/pre_post_install_task_generator.py
@@ -1,32 +1,26 @@
 import re
+import yaml
 
-def create_pre_hook_manifests(source_file, target_file):
-    with open (source_file) as manifest_file:
+def create_hook_based_manifests(hook, source_file, target_file):
+    hook_manifests=open(target_file, 'w')
+    with open (source_file, 'r') as manifest_file:
         content = manifest_file.read()
     helm_hooks = re.search(r'(?<=HOOKS:).*(?=MANIFEST)', content, re.DOTALL).group()
-    helm_pre_hooks = re.sub(r"#\s(Source)(.*)(?:config-bootstrapper)(.+)((?:\n.+)+)\n+.+\n.+", "", helm_hooks)
-    with open(target_file, "w") as pre_hooks:
-        pre_hooks.write(helm_pre_hooks)
-
-def create_post_hook_manifests(source_file, target_file):
-    with open (source_file) as manifest_file:
-        content = manifest_file.read()
-    post_install_hooks = re.search(r"#\s(Source)(.*)(?:config-bootstrapper)(.+)((?:\n.+)+)\n+.+\n", content).group()
-    with open(target_file, "w") as post_hooks:
-        post_hooks.write(post_install_hooks)
+    docs = yaml.load_all(helm_hooks, Loader=yaml.FullLoader)
+    for doc in docs:
+        if (hook in doc["metadata"]["annotations"]["helm.sh/hook"]):
+            hook_manifests.writelines("---\n")
+            yaml.dump(doc, hook_manifests)
 
 def main():
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument('hooks', help='pre or post hook manifests')
+    parser.add_argument('hook', help='pre or post hook manifests')
     parser.add_argument('source_file', help='The path of the manifest source file')
     parser.add_argument('target_file', help='The path to store result manifests')
     args = parser.parse_args()
-    if args.hooks == "pre":
-        create_pre_hook_manifests(args.source_file, args.target_file)
-    elif args.hooks == "post":
-        create_post_hook_manifests(args.source_file, args.target_file)
-    print("manifests created successfully!")
+    create_hook_based_manifests(args.hook, args.source_file, args.target_file)
+    print(args.hook, "manifests created successfully!")
     
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Description
We were separating pre and post install hook manifests using regular expressions to extract config bootstrapper configs. This PR will change that hard coded service based manifest creation to hook based manifest creation. 


### Testing
tested locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
