### PR TITLE
refactor: removed container name from docker-compose to avoid conflict

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,6 @@ services:
 # This container includes the UI and APIs it needs for storage queries.
   hypertrace:
     image: hypertrace/hypertrace:main
-    container_name: hypertrace
     environment:
       - MONGO_HOST=mongo
       - ZK_CONNECT_STR=zookeeper:2181/hypertrace-views
@@ -31,7 +30,6 @@ services:
   # Collects spans in different trace formats like Jaeger, Zipkin, etc
   hypertrace-collector:
     image: hypertrace/hypertrace-collector:main
-    container_name: hypertrace-collector
     ports:
       - 4317:4317 # grpc-otel
       - 55681:55681 # http-otel
@@ -53,7 +51,6 @@ services:
   # all-in-one ingestion pipeline for hypertrace
   hypertrace-ingester:
     image: hypertrace/hypertrace-ingester
-    container_name: hypertrace-ingester
     environment:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - DEFAULT_TENANT_ID=__default
@@ -83,7 +80,6 @@ services:
   # ZooKeeper is required by Kafka and Pinot
   kafka-zookeeper:
     image: hypertrace/kafka-zookeeper:main
-    container_name: kafka-zookeeper
     networks:
       default:
         # prevents apps from having to use the hostname kafka-zookeeper
@@ -93,11 +89,9 @@ services:
   # Stores entities like API, service and backend
   mongo:
     image: hypertrace/mongodb:main
-    container_name: mongo
   # Stores spans and traces and provides aggregation functions
   pinot:
     image: hypertrace/pinot-servicemanager:main
-    container_name: pinot
     environment:
       - LOG_LEVEL=error
     networks:

--- a/docker/postgres/docker-compose.yml
+++ b/docker/postgres/docker-compose.yml
@@ -6,7 +6,6 @@ services:
 # This container includes the UI and APIs it needs for storage queries.
   hypertrace:
     image: hypertrace/hypertrace:main
-    container_name: hypertrace
     environment:
       - DATA_STORE_TYPE=postgres
       - POSTGRES_HOST=postgres
@@ -28,7 +27,6 @@ services:
   # Collects spans in different trace formats like Jaeger, Zipkin, etc
   hypertrace-collector:
     image: hypertrace/hypertrace-collector:main
-    container_name: hypertrace-collector
     ports:
       - 4317:4317 # grpc-otel
       - 55681:55681 # http-otel
@@ -50,7 +48,6 @@ services:
   # all-in-one ingestion pipeline for hypertrace
   hypertrace-ingester:
     image: hypertrace/hypertrace-ingester
-    container_name: hypertrace-ingester
     environment:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - DEFAULT_TENANT_ID=__default
@@ -80,7 +77,6 @@ services:
   # ZooKeeper is required by Kafka and Pinot
   kafka-zookeeper:
     image: hypertrace/kafka-zookeeper:main
-    container_name: kafka-zookeeper
     networks:
       default:
         # prevents apps from having to use the hostname kafka-zookeeper
@@ -98,7 +94,6 @@ services:
   # Stores spans and traces and provides aggregation functions
   pinot:
     image: hypertrace/pinot-servicemanager:main
-    container_name: pinot
     environment:
       - LOG_LEVEL=error
     networks:


### PR DESCRIPTION
## Description
- Removed default container-name from docker-compose file to avoid conflicts by container name with deployments like this:
![image (1)](https://user-images.githubusercontent.com/26570044/118110762-70c6ab80-b400-11eb-8cad-895a333f272e.png)


### Testing
- Tested locally and also runs in e2e test. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

cc: @jcchavezs 
