### PR TITLE
fix: fixed the move of alerting file

### DIFF
--- a/docker/docker-compose.alerting.yml
+++ b/docker/docker-compose.alerting.yml
@@ -1,0 +1,21 @@
+
+version: '2.4'
+services:
+
+  hypertrace-alert-engine:
+    image:  hypertrace/hypertrace-alert-engine
+    container_name: hypertrace-alert-engine
+    environment:
+        - ALERT_RULES_PATH=/app/resources/alert-rules.json
+        - NOTIFICATION_CHANNELS_PATH=/app/resources/notification-rules.json
+        - QUERY_SERVICE_HOST_CONFIG=hypertrace
+        - QUERY_SERVICE_PORT_CONFIG=9001
+        - ATTRIBUTE_SERVICE_HOST_CONFIG=hypertrace
+        - ATTRIBUTE_SERVICE_PORT_CONFIG=9001
+    volumes:
+        - ../docker/configs/alert-rules.json:/app/resources/alert-rules.json:ro
+        - ../docker/configs/notification-rules.json:/app/resources/notification-rules.json:ro
+    depends_on:
+        hypertrace:
+        # service_started, not service_healthy as pinot and deps can take longer than 60s to start
+            condition: service_healthy  


### PR DESCRIPTION
As part of the discussion https://github.com/hypertrace/hypertrace/pull/276#discussion_r685698770, it was to keep both mongo and Postgres in sync for using the single command for starting services with alerting component. However, in the previous PR, the alerting file was accidentally removed. Adding it back to a top-level folder.