### PR TITLE
feat: add docker-compose file for enable metrics pipeline

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -38,12 +38,19 @@ References
 https://github.com/hypertrace/hypertrace/issues/114
 https://github.com/hypertrace/hypertrace/issues/124
 
-#### To start alerting related services
+### To start alerting related services
 
 Run ```docker-compose -f docker-compose.yml  -f docker-compose.alerting.yml up```
 or ```docker-compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.alerting.yml up``` (for postgres as document-store)
 
 Update alerting rule definition in alert-rules.json, notification-rules.json
+
+### Enable metrics pipeline components
+
+To enable the metrics component, include `docker-compose.prometheus.yml` in your docker-compose up/down command.
+
+Run ```docker-compose -f docker-compose.yml  -f docker-compose.prometheus.yml up```
+or ```docker-compose -f docker-compose.yml -f docker-compose.postgres.yml -f docker-compose.prometheus.yml up``` (for postgres as document-store)
 
 ### Ports
 

--- a/docker/docker-compose.prometheus.yml
+++ b/docker/docker-compose.prometheus.yml
@@ -1,0 +1,12 @@
+# This extension enable the metrics pipeline
+version: '2.4'
+services:
+  
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    command: [ "--config.file=/etc/prometheus.yml", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/usr/share/prometheus/console_libraries", "--web.console.templates=/usr/share/prometheus/consoles" ]
+    volumes:
+      - ./prom.yml:/etc/prometheus.yml
+    ports:
+      - "9090:9090"

--- a/docker/docker-compose.prometheus.yml
+++ b/docker/docker-compose.prometheus.yml
@@ -19,10 +19,8 @@ services:
       - PRE_CREATE_TOPICS=true
       - PRODUCER_VALUE_SERDE=org.hypertrace.core.kafkastreams.framework.serdes.GenericAvroSerde
       - METRICS_PIPELINE_ENABLE=true
-      - JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
     ports:
       - 8099:8099
-      - 5005:5005
     depends_on:
       kafka-zookeeper:
         condition: service_healthy

--- a/docker/docker-compose.prometheus.yml
+++ b/docker/docker-compose.prometheus.yml
@@ -1,12 +1,40 @@
 # This extension enable the metrics pipeline
 version: '2.4'
 services:
-  
+  # all-in-one ingestion pipeline for hypertrace
+  hypertrace-ingester:
+    image: traceableai-docker.jfrog.io/hypertrace/hypertrace-ingester:test
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - DEFAULT_TENANT_ID=__default
+      - SPAN_GROUPBY_SESSION_WINDOW_INTERVAL=2
+      - REPLICATION_FACTOR=1
+      - ENTITY_SERVICE_HOST_CONFIG=hypertrace
+      - ENTITY_SERVICE_PORT_CONFIG=9001
+      - ATTRIBUTE_SERVICE_HOST_CONFIG=hypertrace
+      - ATTRIBUTE_SERVICE_PORT_CONFIG=9001
+      - CONFIG_SERVICE_HOST_CONFIG=hypertrace
+      - CONFIG_SERVICE_PORT_CONFIG=9001
+      - NUM_STREAM_THREADS=1
+      - PRE_CREATE_TOPICS=true
+      - PRODUCER_VALUE_SERDE=org.hypertrace.core.kafkastreams.framework.serdes.GenericAvroSerde
+      - METRICS_PIPELINE_ENABLE=true
+      - JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+    ports:
+      - 8099:8099
+      - 5005:5005
+    depends_on:
+      kafka-zookeeper:
+        condition: service_healthy
+      hypertrace:
+        # service_started, not service_healthy as pinot and deps can take longer than 60s to start
+        condition: service_started
+
   prometheus:
     container_name: prometheus
     image: prom/prometheus:latest
-    command: [ "--config.file=/etc/prometheus.yml", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/usr/share/prometheus/console_libraries", "--web.console.templates=/usr/share/prometheus/consoles" ]
+    command: [ "--config.file=/etc/prom.yml", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/usr/share/prometheus/console_libraries", "--web.console.templates=/usr/share/prometheus/consoles" ]
     volumes:
-      - ./prom.yml:/etc/prometheus.yml
+      - ./prom.yml:/etc/prom.yml
     ports:
-      - "9090:9090"
+      - 9090:9090

--- a/docker/docker-compose.prometheus.yml
+++ b/docker/docker-compose.prometheus.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
   # all-in-one ingestion pipeline for hypertrace
   hypertrace-ingester:
-    image: traceableai-docker.jfrog.io/hypertrace/hypertrace-ingester:test
+    image: hypertrace/hypertrace-ingester
     environment:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - DEFAULT_TENANT_ID=__default

--- a/docker/docker-compose.prometheus.yml
+++ b/docker/docker-compose.prometheus.yml
@@ -29,7 +29,6 @@ services:
         condition: service_started
 
   prometheus:
-    container_name: prometheus
     image: prom/prometheus:latest
     command: [ "--config.file=/etc/prom.yml", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/usr/share/prometheus/console_libraries", "--web.console.templates=/usr/share/prometheus/consoles" ]
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,8 +65,8 @@ services:
       - NUM_STREAM_THREADS=1
       - PRE_CREATE_TOPICS=true
       - PRODUCER_VALUE_SERDE=org.hypertrace.core.kafkastreams.framework.serdes.GenericAvroSerde
-    volumes:
-      - ../docker/configs/log4j2.properties:/app/resources/log4j2.properties:ro
+#    volumes:
+#      - ../docker/configs/log4j2.properties:/app/resources/log4j2.properties:ro
     depends_on:
       kafka-zookeeper:
         condition: service_healthy
@@ -104,6 +104,8 @@ services:
           - pinot-controller
           - pinot-server
           - pinot-broker
+    ports:
+      - 9000:9000
     cpu_shares: 2048
     depends_on:
       kafka-zookeeper:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,8 +65,8 @@ services:
       - NUM_STREAM_THREADS=1
       - PRE_CREATE_TOPICS=true
       - PRODUCER_VALUE_SERDE=org.hypertrace.core.kafkastreams.framework.serdes.GenericAvroSerde
-#    volumes:
-#      - ../docker/configs/log4j2.properties:/app/resources/log4j2.properties:ro
+    volumes:
+      - ../docker/configs/log4j2.properties:/app/resources/log4j2.properties:ro
     depends_on:
       kafka-zookeeper:
         condition: service_healthy
@@ -104,8 +104,6 @@ services:
           - pinot-controller
           - pinot-server
           - pinot-broker
-    ports:
-      - 9000:9000
     cpu_shares: 2048
     depends_on:
       kafka-zookeeper:

--- a/docker/prom.yml
+++ b/docker/prom.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: 'hypetrace-metrics-pipeline'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['hypertrace-ingester:8099']


### PR DESCRIPTION
As part of this ticket - https://github.com/hypertrace/hypertrace/issues/327 - on the context of providing application metrics support, this PR,

- adds the new docker-compose file for metrics pipeline
- corresponding hypertrace-ingester PR - https://github.com/hypertrace/hypertrace-ingester/pull/292